### PR TITLE
Min weighted vertex cover closes #6

### DIFF
--- a/docs/reference/algorithms/cover.rst
+++ b/docs/reference/algorithms/cover.rst
@@ -20,5 +20,6 @@ set.
 .. autosummary::
    :toctree: generated/
 
+   min_weighted_vertex_cover
    min_vertex_cover
    is_vertex_cover

--- a/docs/reference/algorithms/packing.rst
+++ b/docs/reference/algorithms/packing.rst
@@ -20,5 +20,6 @@ of its member pairs.
 .. autosummary::
    :toctree: generated/
 
+    maximum_weighted_independent_set
     maximum_independent_set
     is_independent_set

--- a/dwave_networkx/algorithms/cover.py
+++ b/dwave_networkx/algorithms/cover.py
@@ -1,7 +1,66 @@
-from dwave_networkx.algorithms.independent_set import maximum_independent_set
+from dwave_networkx.algorithms.independent_set import maximum_weighted_independent_set
 from dwave_networkx.utils import binary_quadratic_model_sampler
 
-__all__ = ['min_vertex_cover', 'is_vertex_cover']
+__all__ = ['min_weighted_vertex_cover', 'min_vertex_cover', 'is_vertex_cover']
+
+
+@binary_quadratic_model_sampler(2)
+def min_weighted_vertex_cover(G, weight=None, sampler=None, **sampler_args):
+    """Returns an approximate minimum weighted vertex cover.
+
+    Defines a QUBO with ground states corresponding to a minimum
+    vertex cover and uses the sampler to sample from it.
+
+    A vertex cover is a set of vertices such that each edge of the graph
+    is incident with at least one vertex in the set. A minimum vertex cover
+    is the vertex cover of minimum total node weight.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    weight : string, optional (default None)
+        If None, every node has equal weight. If a string, use this node
+        attribute as the node weight. A node without this attribute is
+        assumed to have max weight.
+
+    sampler
+        A binary quadratic model sampler. A sampler is a process that
+        samples from low energy states in models defined by an Ising
+        equation or a Quadratic Unconstrained Binary Optimization
+        Problem (QUBO). A sampler is expected to have a 'sample_qubo'
+        and 'sample_ising' method. A sampler is expected to return an
+        iterable of samples, in order of increasing energy. If no
+        sampler is provided, one must be provided using the
+        `set_default_sampler` function.
+
+    sampler_args
+        Additional keyword parameters are passed to the sampler.
+
+    Returns
+    -------
+    vertex_cover : list
+       List of nodes that the form a the minimum vertex cover, as
+       determined by the given sampler.
+
+    Notes
+    -----
+    Samplers by their nature may not return the optimal solution. This
+    function does not attempt to confirm the quality of the returned
+    sample.
+
+    https://en.wikipedia.org/wiki/Vertex_cover
+
+    https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization
+
+    References
+    ----------
+    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
+       Frontiers in Physics, Volume 2, Article 5.
+
+    """
+    indep_nodes = set(maximum_weighted_independent_set(G, weight, sampler, **sampler_args))
+    return [v for v in G if v not in indep_nodes]
 
 
 @binary_quadratic_model_sampler(1)
@@ -74,8 +133,7 @@ def min_vertex_cover(G, sampler=None, **sampler_args):
        Frontiers in Physics, Volume 2, Article 5.
 
     """
-    indep_nodes = set(maximum_independent_set(G, sampler, **sampler_args))
-    return [v for v in G if v not in indep_nodes]
+    return min_weighted_vertex_cover(G, None, sampler, **sampler_args)
 
 
 def is_vertex_cover(G, vertex_cover):

--- a/dwave_networkx/algorithms/cover.py
+++ b/dwave_networkx/algorithms/cover.py
@@ -8,12 +8,12 @@ __all__ = ['min_weighted_vertex_cover', 'min_vertex_cover', 'is_vertex_cover']
 def min_weighted_vertex_cover(G, weight=None, sampler=None, **sampler_args):
     """Returns an approximate minimum weighted vertex cover.
 
-    Defines a QUBO with ground states corresponding to a minimum
+    Defines a QUBO with ground states corresponding to a minimum weighted
     vertex cover and uses the sampler to sample from it.
 
     A vertex cover is a set of vertices such that each edge of the graph
-    is incident with at least one vertex in the set. A minimum vertex cover
-    is the vertex cover of minimum total node weight.
+    is incident with at least one vertex in the set. A minimum weighted
+    vertex cover is the vertex cover of minimum total node weight.
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def min_weighted_vertex_cover(G, weight=None, sampler=None, **sampler_args):
     Returns
     -------
     vertex_cover : list
-       List of nodes that the form a the minimum vertex cover, as
+       List of nodes that the form a the minimum weighted vertex cover, as
        determined by the given sampler.
 
     Notes
@@ -55,8 +55,7 @@ def min_weighted_vertex_cover(G, weight=None, sampler=None, **sampler_args):
 
     References
     ----------
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Based on the formulation presented in [AL]_
 
     """
     indep_nodes = set(maximum_weighted_independent_set(G, weight, sampler, **sampler_args))

--- a/dwave_networkx/algorithms/independent_set.py
+++ b/dwave_networkx/algorithms/independent_set.py
@@ -1,6 +1,90 @@
 from dwave_networkx.utils import binary_quadratic_model_sampler
 
-__all__ = ["maximum_independent_set", "is_independent_set"]
+__all__ = ["maximum_weighted_independent_set", "maximum_independent_set", "is_independent_set"]
+
+
+@binary_quadratic_model_sampler(2)
+def maximum_weighted_independent_set(G, weight=None, sampler=None, **sampler_args):
+    """Returns an approximate maximum weighted independent set.
+
+    Defines a QUBO with ground states corresponding to a
+    maximum weighted independent set and uses the sampler to sample
+    from it.
+
+    An independent set is a set of nodes such that the subgraph
+    of G induced by these nodes contains no edges. A maximum
+    independent set is an independent set of maximum total node weight.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph on which to find a maximum cut weighted independent set.
+
+    weight : string, optional (default None)
+        If None, every node has equal weight. If a string, use this node
+        attribute as the node weight. A node without this attribute is
+        assumed to have max weight.
+
+    sampler
+        A binary quadratic model sampler. A sampler is a process that
+        samples from low energy states in models defined by an Ising
+        equation or a Quadratic Unconstrained Binary Optimization
+        Problem (QUBO). A sampler is expected to have a 'sample_qubo'
+        and 'sample_ising' method. A sampler is expected to return an
+        iterable of samples, in order of increasing energy. If no
+        sampler is provided, one must be provided using the
+        `set_default_sampler` function.
+
+    sampler_args
+        Additional keyword parameters are passed to the sampler.
+
+    Returns
+    -------
+    indep_nodes : list
+       List of nodes that form a maximum weighted independent set, as
+       determined by the given sampler.
+
+    Notes
+    -----
+    Samplers by their nature may not return the optimal solution. This
+    function does not attempt to confirm the quality of the returned
+    sample.
+
+    References
+    ----------
+
+    `Independent Set on Wikipedia <https://en.wikipedia.org/wiki/Independent_set_(graph_theory)>`_
+
+    `QUBO on Wikipedia <https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization>`_
+
+    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
+       Frontiers in Physics, Volume 2, Article 5.
+
+    """
+
+    # We assume that the sampler can handle an unstructured QUBO problem, so let's set one up.
+    # Let us define the largest independent set to be S.
+    # For each node n in the graph, we assign a boolean variable v_n, where v_n = 1 when n
+    # is in S and v_n = 0 otherwise.
+    # We call the matrix defining our QUBO problem Q.
+    # On the diagnonal, we assign the linear bias for each node to be the negative of its weight.
+    # This means that each node is biased towards being in S. Weights are scaled to a maximum of 1.
+    # Negative weights are considered 0.
+    # On the off diagnonal, we assign the off-diagonal terms of Q to be 2. Thus, if both
+    # nodes are in S, the overall energy is increased by 2.
+    cost = dict(G.nodes(data=weight, default=1))
+    scale = max(cost.values())
+    Q = {(node, node): min(-cost[node] / scale, 0) for node in G}
+    Q.update({edge: 2 for edge in G.edges})
+
+    # use the sampler to find low energy states
+    response = sampler.sample_qubo(Q, **sampler_args)
+
+    # we want the lowest energy sample
+    sample = next(iter(response))
+
+    # nodes that are spin up or true are exactly the ones in S.
+    return [node for node in sample if sample[node] > 0]
 
 
 @binary_quadratic_model_sampler(1)
@@ -70,27 +154,7 @@ def maximum_independent_set(G, sampler=None, **sampler_args):
        Frontiers in Physics, Volume 2, Article 5.
 
     """
-
-    # We assume that the sampler can handle an unstructured QUBO problem, so let's set one up.
-    # Let us define the largest independent set to be S.
-    # For each node n in the graph, we assign a boolean variable v_n, where v_n = 1 when n
-    # is in S and v_n = 0 otherwise.
-    # We call the matrix defining our QUBO problem Q.
-    # On the diagnonal, we assign the linear bias for each node to be -1. This means that each
-    # node is biased towards being in S
-    # On the off diagnonal, we assign the off-diagonal terms of Q to be 2. Thus, if both
-    # nodes are in S, the overall energy is increased by 2.
-    Q = {(node, node): -1 for node in G}
-    Q.update({edge: 2 for edge in G.edges})
-
-    # use the sampler to find low energy states
-    response = sampler.sample_qubo(Q, **sampler_args)
-
-    # we want the lowest energy sample
-    sample = next(iter(response))
-
-    # nodes that are spin up or true are exactly the ones in S.
-    return [node for node in sample if sample[node] > 0]
+    return maximum_weighted_independent_set(G, None, sampler, **sampler_args)
 
 
 def is_independent_set(G, indep_nodes):

--- a/dwave_networkx/algorithms/independent_set.py
+++ b/dwave_networkx/algorithms/independent_set.py
@@ -64,7 +64,7 @@ def maximum_weighted_independent_set(G, weight=None, sampler=None, **sampler_arg
 
     """
 
-    response = _weighted_independent_sets(G, weight, sampler, **sampler_args)
+    response = maximum_weighted_independent_set_response(G, weight, sampler, **sampler_args)
 
     # we want the lowest energy sample
     sample = next(iter(response))
@@ -182,7 +182,7 @@ def is_independent_set(G, indep_nodes):
 
 
 @binary_quadratic_model_sampler(2)
-def _weighted_independent_sets(G, weight=None, sampler=None, **sampler_args):
+def maximum_weighted_independent_set_response(G, weight=None, sampler=None, **sampler_args):
     """Returns candidate weighted independent sets.
 
     Defines a QUBO with ground states corresponding to a

--- a/dwave_networkx/algorithms/independent_set.py
+++ b/dwave_networkx/algorithms/independent_set.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from dwave_networkx.utils import binary_quadratic_model_sampler
 
 __all__ = ["maximum_weighted_independent_set", "maximum_independent_set", "is_independent_set"]

--- a/dwave_networkx/algorithms/tests/test_cover.py
+++ b/dwave_networkx/algorithms/tests/test_cover.py
@@ -1,4 +1,5 @@
 import unittest
+import random
 
 import networkx as nx
 import dwave_networkx as dnx
@@ -6,10 +7,16 @@ import dwave_networkx as dnx
 from dimod import ExactSolver, SimulatedAnnealingSampler
 
 
+#######################################################################################
+# Unit Tests
+#######################################################################################
+
 class TestCover(unittest.TestCase):
 
     def test_vertex_cover_basic(self):
-
+        """Runs the function on some small and simple graphs, just to make
+        sure it works in basic functionality.
+        """
         G = dnx.chimera_graph(1, 2, 2)
         cover = dnx.min_vertex_cover(G, ExactSolver())
         self.vertex_cover_check(G, cover)
@@ -21,6 +28,31 @@ class TestCover(unittest.TestCase):
         for __ in range(10):
             G = nx.gnp_random_graph(5, .5)
             cover = dnx.min_vertex_cover(G, ExactSolver())
+            self.vertex_cover_check(G, cover)
+
+    def test_vertex_cover_weighted(self):
+        weight = 'weight'
+        G = nx.path_graph(6)
+
+        # favor even nodes
+        nx.set_node_attributes(G, {node: node % 2 + 1 for node in G}, weight)
+        cover = dnx.min_weighted_vertex_cover(G, weight, ExactSolver())
+        self.assertEqual(set(cover), {0, 2, 4})
+
+        # favor odd nodes
+        nx.set_node_attributes(G, {node: (node + 1) % 2 + 1 for node in G}, weight)
+        cover = dnx.min_weighted_vertex_cover(G, weight, ExactSolver())
+        self.assertEqual(set(cover), {1, 3, 5})
+
+        # make nodes 1 and 4 unlikely
+        nx.set_node_attributes(G, {0: 1, 1: 3, 2: 1, 3: 1, 4: 3, 5: 1}, weight)
+        cover = dnx.min_weighted_vertex_cover(G, weight, ExactSolver())
+        self.assertEqual(set(cover), {0, 2, 3, 5})
+
+        for __ in range(10):
+            G = nx.gnp_random_graph(5, .5)
+            nx.set_node_attributes(G, {node: random.random() for node in G}, weight)
+            cover = dnx.min_weighted_vertex_cover(G, weight, ExactSolver())
             self.vertex_cover_check(G, cover)
 
     def test_default_sampler(self):

--- a/dwave_networkx/algorithms/tests/test_independent_set.py
+++ b/dwave_networkx/algorithms/tests/test_independent_set.py
@@ -1,7 +1,12 @@
 import unittest
+import random
+
+# import os
+# import matplotlib.pyplot as plt
 
 import networkx as nx
 import dwave_networkx as dnx
+from dwave_networkx.algorithms.independent_set import _weighted_independent_sets
 
 from dimod import ExactSolver, SimulatedAnnealingSampler
 
@@ -16,7 +21,6 @@ class TestIndepSet(unittest.TestCase):
         """Runs the function on some small and simple graphs, just to make
         sure it works in basic functionality.
         """
-
         G = dnx.chimera_graph(1, 2, 2)
         indep_set = dnx.maximum_independent_set(G, ExactSolver())
         self.set_independence_check(G, indep_set)
@@ -28,6 +32,31 @@ class TestIndepSet(unittest.TestCase):
         for __ in range(10):
             G = nx.gnp_random_graph(5, .5)
             indep_set = dnx.maximum_independent_set(G, ExactSolver())
+            self.set_independence_check(G, indep_set)
+
+    def test_maximum_independent_set_weighted(self):
+        weight = 'weight'
+        G = nx.path_graph(6)
+
+        # favor odd nodes
+        nx.set_node_attributes(G, {node: node % 2 + 1 for node in G}, weight)
+        indep_set = dnx.maximum_weighted_independent_set(G, weight, ExactSolver())
+        self.assertEqual(set(indep_set), {1, 3, 5})
+
+        # favor even nodes
+        nx.set_node_attributes(G, {node: (node + 1) % 2 + 1 for node in G}, weight)
+        indep_set = dnx.maximum_weighted_independent_set(G, weight, ExactSolver())
+        self.assertEqual(set(indep_set), {0, 2, 4})
+
+        # make nodes 1 and 4 likely
+        nx.set_node_attributes(G, {0: 1, 1: 3, 2: 1, 3: 1, 4: 3, 5: 1}, weight)
+        indep_set = dnx.maximum_weighted_independent_set(G, weight, ExactSolver())
+        self.assertEqual(set(indep_set), {1, 4})
+
+        for __ in range(10):
+            G = nx.gnp_random_graph(5, .5)
+            nx.set_node_attributes(G, {node: random.random() for node in G}, weight)
+            indep_set = dnx.maximum_weighted_independent_set(G, weight, ExactSolver())
             self.set_independence_check(G, indep_set)
 
     def test_default_sampler(self):
@@ -44,6 +73,41 @@ class TestIndepSet(unittest.TestCase):
 
         indep_set = dnx.maximum_independent_set(G, ExactSolver())
         indep_set = dnx.maximum_independent_set(G, SimulatedAnnealingSampler())
+
+    def test__weighted_independent_sets(self):
+        weight = 'weight'
+
+        for i in range(10):
+            G = nx.gnp_random_graph(5, .5)
+            nx.set_node_attributes(G, {node: random.random() for node in G}, weight)
+            response = _weighted_independent_sets(G, weight, ExactSolver())
+
+            # Independent sets should be ordered from highest to lowest total weight
+            prevSum = float('Inf')
+            for sample in response.samples():
+                candidate_set = [node for node in sample if sample[node] > 0]
+                if dnx.is_independent_set(G, candidate_set):
+                    curSum = sum((attributes[weight] for v, attributes in G.nodes(data=True) if v in candidate_set))
+                    self.assertGreaterEqual(prevSum, curSum)
+                    prevSum = curSum
+
+            # # Draw graphs
+            # pos = nx.spring_layout(G)
+            # labels = nx.get_node_attributes(G, weight)
+            # weights = labels.values()
+            # minweight = min(weights)
+            # node_size = [x / minweight * 300 for x in weights]
+            # for j, (sample, energy) in enumerate(response.items()):
+            #     directory_path = os.path.join('tmp', '%d' % i)
+            #     if not os.path.exists(directory_path):
+            #         os.makedirs(directory_path)
+            #     file_path = os.path.join(directory_path, '%s.png' % j)
+            #     nx.draw_networkx(G, pos, node_size=node_size, node_color=list(
+            #         sample.values()), cmap="tab10", labels=sample)
+            #     plt.title(energy)
+            #     plt.savefig(file_path)
+            #     plt.clf()
+
 
 #######################################################################################
 # Helper functions

--- a/dwave_networkx/algorithms/tests/test_independent_set.py
+++ b/dwave_networkx/algorithms/tests/test_independent_set.py
@@ -6,7 +6,7 @@ import random
 
 import networkx as nx
 import dwave_networkx as dnx
-from dwave_networkx.algorithms.independent_set import _weighted_independent_sets
+from dwave_networkx.algorithms.independent_set import maximum_weighted_independent_set_response
 
 from dimod import ExactSolver, SimulatedAnnealingSampler
 
@@ -80,7 +80,7 @@ class TestIndepSet(unittest.TestCase):
         for i in range(10):
             G = nx.gnp_random_graph(5, .5)
             nx.set_node_attributes(G, {node: random.random() for node in G}, weight)
-            response = _weighted_independent_sets(G, weight, ExactSolver())
+            response = maximum_weighted_independent_set_response(G, weight, ExactSolver())
 
             # Independent sets should be ordered from highest to lowest total weight
             prevSum = float('Inf')


### PR DESCRIPTION
Weighted version of `min_vertex_cover()`
- Since `min_vertex_cover()` was implemented by calling `maximum_independent_set()`, implemented `maximum_weighted_independent_set()` which is used by `min_weighted_vertex_cover()`
- Both `min_vertex_cover()` and `maximum_independent_set()` now are implemented by calling their weighted versions with `weight=None`

Closes #6 