### PR TITLE
Draw qubit graph yield

### DIFF
--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -310,7 +310,7 @@ def draw_chimera_yield(G, **kwargs):
 
     fault_shape : string, optional (default='x')
         The shape of the fault nodes. Specification is as matplotlib.scatter
-        marker, one of ‘so^>v<dph8’.
+        marker, one of 'so^>v<dph8'.
 
     fault_style : string, optional (default='dashed')
         Edge fault line style (solid|dashed|dotted,dashdot)

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -23,8 +23,8 @@ import networkx as nx
 from networkx import draw
 
 from dwave_networkx import _PY2
-from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding
-from dwave_networkx.generators.chimera import find_chimera_indices, chimera_coordinates
+from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield
+from dwave_networkx.generators.chimera import chimera_graph, find_chimera_indices, chimera_coordinates
 
 # compatibility for python 2/3
 if _PY2:
@@ -38,7 +38,7 @@ else:
 
     def iteritems(d): return d.items()
 
-__all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding']
+__all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding', 'draw_chimera_yield']
 
 
 def chimera_layout(G, scale=1., center=None, dim=2):
@@ -290,3 +290,47 @@ def draw_chimera_embedding(G, *args, **kwargs):
        any provided `node_color` or `edge_color` arguments are ignored.
     """
     draw_embedding(G, chimera_layout(G), *args, **kwargs)
+
+
+def draw_chimera_yield(G, **kwargs):
+    """Draws the given graph G with highlighted faults, according to layout.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be parsed for faults
+
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
+        The color to use for nodes and edges of G which are not faults.
+        If unused_color is None, these nodes and edges will not be shown at all.
+
+    fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
+        A color to represent nodes absent from the graph G. Colors should be
+        length-4 tuples of floats between 0 and 1 inclusive.
+
+    fault_shape : string, optional (default='x')
+        The shape of the fault nodes. Specification is as matplotlib.scatter
+        marker, one of ‘so^>v<dph8’.
+
+    fault_style : string, optional (default='dashed')
+        Edge fault line style (solid|dashed|dotted,dashdot)
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+    """
+    try:
+        assert(G.graph["family"] == "chimera")
+        m = G.graph["columns"]
+        n = G.graph["rows"]
+        t = G.graph["tile"]
+        coordinates = G.graph["labels"] == "coordinate"
+    except:
+        raise ValueError("Target chimera graph needs to have columns, rows, \
+        tile, and label attributes to be able to identify faulty qubits.")
+
+    perfect_graph = chimera_graph(m,n,t, coordinates=coordinates)
+
+    draw_yield(G, chimera_layout(perfect_graph), perfect_graph, **kwargs)

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -23,8 +23,8 @@ import networkx as nx
 from networkx import draw
 
 from dwave_networkx import _PY2
-from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding
-from dwave_networkx.generators.pegasus import pegasus_coordinates
+from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield
+from dwave_networkx.generators.pegasus import pegasus_graph, pegasus_coordinates
 from dwave_networkx.drawing.chimera_layout import chimera_node_placer_2d
 
 # compatibility for python 2/3
@@ -39,7 +39,7 @@ else:
 
     def iteritems(d): return d.items()
 
-__all__ = ['pegasus_layout', 'draw_pegasus', 'draw_pegasus_embedding']
+__all__ = ['pegasus_layout', 'draw_pegasus', 'draw_pegasus_embedding', 'draw_pegasus_yield']
 
 
 def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
@@ -285,3 +285,47 @@ def draw_pegasus_embedding(G, *args, **kwargs):
     """
     crosses = kwargs.pop("crosses", False)
     draw_embedding(G, pegasus_layout(G, crosses=crosses), *args, **kwargs)
+
+def draw_pegasus_yield(G, **kwargs):
+    """Draws the given graph G with highlighted faults, according to layout.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be parsed for faults
+
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
+        The color to use for nodes and edges of G which are not faults.
+        If unused_color is None, these nodes and edges will not be shown at all.
+
+    fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
+        A color to represent nodes absent from the graph G. Colors should be
+        length-4 tuples of floats between 0 and 1 inclusive.
+
+    fault_shape : string, optional (default='x')
+        The shape of the fault nodes. Specification is as matplotlib.scatter
+        marker, one of ‘so^>v<dph8’.
+
+    fault_style : string, optional (default='dashed')
+        Edge fault line style (solid|dashed|dotted,dashdot)
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+    """
+    try:
+        assert(G.graph["family"] == "pegasus")
+        m = G.graph['columns']
+        offset_lists = (G.graph['vertical_offsets'], G.graph['horizontal_offsets'])
+        coordinates = G.graph["labels"] == "coordinate"
+        # Can't interpret fabric_only from graph attributes
+    except:
+        raise ValueError("Target pegasus graph needs to have columns, rows, \
+        tile, and label attributes to be able to identify faulty qubits.")
+
+
+    perfect_graph = pegasus_graph(m, offset_lists=offset_lists, coordinates=coordinates)
+
+    draw_yield(G, pegasus_layout(perfect_graph), perfect_graph, **kwargs)

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -304,7 +304,7 @@ def draw_pegasus_yield(G, **kwargs):
 
     fault_shape : string, optional (default='x')
         The shape of the fault nodes. Specification is as matplotlib.scatter
-        marker, one of ‘so^>v<dph8’.
+        marker, one of 'so^>v<dph8'.
 
     fault_style : string, optional (default='dashed')
         Edge fault line style (solid|dashed|dotted,dashdot)

--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -316,7 +316,7 @@ def draw_yield(G, layout, perfect_graph, unused_color=(0.9,0.9,0.9,1.0),
 
     fault_shape : string, optional (default='x')
         The shape of the fault nodes. Specification is as matplotlib.scatter
-        marker, one of ‘so^>v<dph8’.
+        marker, one of 'so^>v<dph8'.
 
     fault_style : string, optional (default='dashed')
         Edge fault line style (solid|dashed|dotted,dashdot)

--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -190,7 +190,7 @@ def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
         tuples of floats between 0 and 1 inclusive. If chain_color is None,
         each chain will be assigned a different color.
 
-    unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         The color to use for nodes and edges of G which are not involved
         in chains, and edges which are neither chain edges nor interactions.
         If unused_color is None, these nodes and edges will not be shown at all.
@@ -206,6 +206,11 @@ def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
         import matplotlib as mpl
     except ImportError:
         raise ImportError("Matplotlib and numpy required for draw_chimera()")
+
+    if nx.utils.is_string_like(unused_color):
+        from matplotlib.colors import colorConverter
+        alpha = kwargs.get('alpha',1.0)
+        unused_color = colorConverter.to_rgba(unused_color,alpha)
 
     if chain_color is None:
         import matplotlib.cm
@@ -280,3 +285,80 @@ def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
     draw(G, layout, nodelist=nodelist, edgelist=edgelist,
          node_color=node_color, edge_color=edge_color, labels=labels,
          **kwargs)
+
+def draw_yield(G, layout, perfect_graph, unused_color=(0.9,0.9,0.9,1.0),
+                    fault_color=(1.0,0.0,0.0,1.0), fault_shape='x',
+                    fault_style='dashed', **kwargs):
+
+    """Draws the given graph G with highlighted faults, according to layout.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be parsed for faults
+
+    layout : dict
+        A dict of coordinates associated with each node in perfect_graph. Should
+        be of the form {node: coordinate, ...}.  Coordinates will be
+        treated as vectors, and should all have the same length.
+
+    perfect_graph : NetworkX graph
+        The graph to be drawn with highlighted faults
+
+
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
+        The color to use for nodes and edges of G which are not faults.
+        If unused_color is None, these nodes and edges will not be shown at all.
+
+    fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
+        A color to represent nodes absent from the graph G. Colors should be
+        length-4 tuples of floats between 0 and 1 inclusive.
+
+    fault_shape : string, optional (default='x')
+        The shape of the fault nodes. Specification is as matplotlib.scatter
+        marker, one of ‘so^>v<dph8’.
+
+    fault_style : string, optional (default='dashed')
+        Edge fault line style (solid|dashed|dotted,dashdot)
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib as mpl
+    except ImportError:
+        raise ImportError("Matplotlib and numpy required for draw_chimera()")
+
+    nodelist = G.nodes()
+    edgelist = G.edges()
+    faults_nodelist = perfect_graph.nodes() - nodelist
+    faults_edgelist = perfect_graph.edges() - edgelist
+
+    # To avoid matplotlib.pyplot.scatter warnings for single tuples, create
+    # lists of colors from given colors.
+    faults_node_color = [fault_color for v in faults_nodelist]
+    faults_edge_color = [fault_color for v in faults_edgelist]
+
+    # Draw faults with different style and shape
+    draw(perfect_graph, layout, nodelist=faults_nodelist, edgelist=faults_edgelist,
+        node_color=faults_node_color, edge_color=faults_edge_color,
+        style=fault_style, node_shape=fault_shape,
+        **kwargs )
+
+    # Draw rest of graph
+    if unused_color is not None:
+        if nodelist is None:
+            nodelist = G.nodes() - faults_nodelist
+        if edgelist is None:
+            edgelist = G.edges() - faults_edgelist
+
+        unused_node_color = [unused_color for v in nodelist]
+        unused_edge_color = [unused_color for v in edgelist]
+
+        draw(perfect_graph, layout, nodelist=nodelist, edgelist=edgelist,
+            node_color=unused_node_color, edge_color=unused_edge_color,
+            **kwargs)

--- a/dwave_networkx/drawing/tests/test_chimera_layout.py
+++ b/dwave_networkx/drawing/tests/test_chimera_layout.py
@@ -97,6 +97,13 @@ class TestDrawing(unittest.TestCase):
         G = dnx.chimera_graph(1, 1, 16, data=False)
         pos = dnx.chimera_layout(G.edges())
 
+    @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
+    @unittest.skipUnless(_display, " No display found")
+    def test_draw_chimera_yield(self):
+        G = dnx.chimera_graph(2, 2, 4, data=False)
+        G.remove_edges_from([(0,6),(10,13),(26,31)])
+        G.remove_nodes_from([18,23])
+        dnx.draw_chimera_yield(G)
 
     @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
     @unittest.skipUnless(_display, " No display found")

--- a/dwave_networkx/drawing/tests/test_chimera_layout.py
+++ b/dwave_networkx/drawing/tests/test_chimera_layout.py
@@ -107,7 +107,7 @@ class TestDrawing(unittest.TestCase):
 
     @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
     @unittest.skipUnless(_display, " No display found")
-    def test_draw_pegasus_biases(self):
+    def test_draw_chimera_biases(self):
         G = dnx.chimera_graph(8)
         h = {v: v % 12 for v in G}
         J = {(u, v) if u % 2 else (v, u): (u+v) % 24 for u, v in G.edges()}
@@ -118,7 +118,7 @@ class TestDrawing(unittest.TestCase):
 
     @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
     @unittest.skipUnless(_display, " No display found")
-    def test_draw_pegasus_embedding(self):
+    def test_draw_chimera_embedding(self):
         C = dnx.chimera_graph(4)
         G = nx.grid_graph([2, 3, 2])
         emb = {(0, 0, 0): [80, 48], (0, 0, 1): [50, 52], (0, 1, 0): [85, 93],

--- a/dwave_networkx/drawing/tests/test_pegasus_layout.py
+++ b/dwave_networkx/drawing/tests/test_pegasus_layout.py
@@ -81,6 +81,14 @@ class TestDrawing(unittest.TestCase):
 
     @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
     @unittest.skipUnless(_display, " No display found")
+    def test_draw_pegasus_yield(self):
+        G = dnx.pegasus_graph(3, data=False)
+        G.remove_edges_from([(5,104),(12,96),(23,112)])
+        G.remove_nodes_from([109,139])
+        dnx.draw_pegasus_yield(G)
+
+    @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
+    @unittest.skipUnless(_display, " No display found")
     def test_draw_pegasus_biases(self):
         G = dnx.pegasus_graph(2)
         h = {v: v % 12 for v in G}


### PR DESCRIPTION
Simple implementation to highlight faults in Chimera or Pegasus graphs.
Example usage:
```
G = dnx.chimera_graph(2, 2, 4, data=False)
G.remove_edges_from([(0,6),(10,13),(26,31)])
G.remove_nodes_from([18,23])
dnx.draw_chimera_yield(G)
plt.show()
```

```
G = dnx.pegasus_graph(3, data=False)
G.remove_edges_from([(5,104),(12,96),(23,112)])
G.remove_nodes_from([109,139])
dnx.draw_pegasus_yield(G)
plt.show()
```

It's also possible to use before a draw_..._embedding() because it differentiates faults with node shape ='x' and edge style = 'dashed'

Also modified description of unused_color which allows color strings and a minor typo in test_chimera_layout.
