### PR TITLE
Support NetworkX>=2.4

### DIFF
--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -193,11 +193,11 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         if coordinates:
             def checkadd(v, q):
                 if q in G:
-                    G.node[q]['linear_index'] = v
+                    G.nodes[q]['linear_index'] = v
         else:
             def checkadd(v, q):
                 if v in G:
-                    G.node[v]['chimera_index'] = q
+                    G.nodes[v]['chimera_index'] = q
 
         v = 0
         for i in range(m):

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -261,14 +261,14 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
                         if nice_coordinates:
                             p = c2i(*q)
                             if p in G:
-                                G.node[p]['linear_index'] = v
-                                G.node[p]['pegasus_index'] = q
+                                G.nodes[p]['linear_index'] = v
+                                G.nodes[p]['pegasus_index'] = q
                         elif coordinates:
                             if q in G:
-                                G.node[q]['linear_index'] = v
+                                G.nodes[q]['linear_index'] = v
                         else:
                             if v in G:
-                                G.node[v]['pegasus_index'] = q
+                                G.nodes[v]['pegasus_index'] = q
                         v += 1
 
     return G

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-networkx==2.4
+networkx==2.2; python_version<="3.4"
+networkx==2.4; python_version>="3.5"
 decorator==4.3.0
 dimod==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-networkx==2.2
-decorator==4.1.0
+networkx==2.4
+decorator==4.3.0
 dimod==0.8.0


### PR DESCRIPTION
NetworkX made a backwards compatibility breaking change. I have also tested this change for NetworkX==2.0.

See also:
https://github.com/dwavesystems/dwave-hybrid/issues/211