### PR TITLE
Use gcf and gca to get/create figure axes in qubit graph

### DIFF
--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -139,8 +139,8 @@ def draw_qubit_graph(G, layout, linear_biases={}, quadratic_biases={},
         if edge_vmax is None:
             edge_vmax = vmag
 
-    fig = plt.figure(1)
-    ax = kwargs.pop('ax',None)
+    fig = plt.gcf()
+    ax = kwargs.pop('ax', plt.gca())
     cax = kwargs.pop('cax',None)
     if linear_biases or quadratic_biases:
         if ax is None:


### PR DESCRIPTION
I noticed that using `dnx.draw_chimera` under a `plt.subplot(...)` would fail because of the use of `plt.figure(1)` inside `draw_qubit_graph`.

I think it can be fixed this way.
plt.gcf(): _Get the current figure. If no current figure exists, a new one is created using figure()._

Then, plt.gca() is also necessary. The `cax` is OK as is.