### PR TITLE
Fix incorrect assignment of columns and rows for draw_yield

### DIFF
--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -323,8 +323,8 @@ def draw_chimera_yield(G, **kwargs):
     """
     try:
         assert(G.graph["family"] == "chimera")
-        m = G.graph["columns"]
-        n = G.graph["rows"]
+        m = G.graph["rows"]
+        n = G.graph["columns"]
         t = G.graph["tile"]
         coordinates = G.graph["labels"] == "coordinate"
     except:


### PR DESCRIPTION
Oops, this was my bad when I pushed draw_yield(...)
I only caught when I tried using oblong Chimeras... which are not normally used.
