### PR TITLE
removed calls to deprecated coordinate translators

### DIFF
--- a/dwave_networkx/algorithms/elimination_ordering.py
+++ b/dwave_networkx/algorithms/elimination_ordering.py
@@ -917,4 +917,4 @@ def pegasus_elimination_order(n, coordinates=False):
     if coordinates:
         return order
     else:
-        return pegasus_coordinates(n).ints(order)
+        return pegasus_coordinates(n).iter_pegasus_to_linear(order)

--- a/dwave_networkx/algorithms/tests/test_canonicalization.py
+++ b/dwave_networkx/algorithms/tests/test_canonicalization.py
@@ -42,7 +42,7 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
         coord = chimera_coordinates(1, 1, 4)
 
         labels = canonical_chimera_labeling(C1)
-        labels = {v: coord.int(labels[v]) for v in labels}
+        labels = {v: coord.chimera_to_linear(labels[v]) for v in labels}
 
         G = nx.relabel_nodes(C1, labels, copy=True)
 
@@ -54,7 +54,7 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
         coord = chimera_coordinates(1, 1, 4)
 
         labels = canonical_chimera_labeling(C1bqm)
-        labels = {v: coord.int(labels[v]) for v in labels}
+        labels = {v: coord.chimera_to_linear(labels[v]) for v in labels}
 
         bqm = C1bqm.relabel_variables(labels, inplace=False)
 
@@ -65,7 +65,7 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
         coord = chimera_coordinates(4, 1, 4)
 
         labels = canonical_chimera_labeling(C41)
-        labels = {v: coord.int(labels[v]) for v in labels}
+        labels = {v: coord.chimera_to_linear(labels[v]) for v in labels}
 
         G = nx.relabel_nodes(C41, labels, copy=True)
 
@@ -76,7 +76,7 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
         coord = chimera_coordinates(3, 3, 4)
 
         labels = canonical_chimera_labeling(C33)
-        labels = {v: coord.int(labels[v]) for v in labels}
+        labels = {v: coord.chimera_to_linear(labels[v]) for v in labels}
 
         G = nx.relabel_nodes(C33, labels, copy=True)
 
@@ -97,7 +97,7 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
         assert len(bqm) == len(C22)
 
         labels = canonical_chimera_labeling(bqm)
-        labels = {v: alpha[coord.int(labels[v])] for v in labels}
+        labels = {v: alpha[coord.chimera_to_linear(labels[v])] for v in labels}
 
         bqm2 = bqm.relabel_variables(labels, inplace=False)
 

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -97,7 +97,7 @@ def chimera_layout(G, scale=1., center=None, dim=2):
             pos = {v: xy_coords(*dat['chimera_index']) for v, dat in G.nodes(data=True)}
         else:
             coord = chimera_coordinates(m, n, t)
-            pos = {v: xy_coords(*coord.tuple(v)) for v in G.nodes()}
+            pos = {v: xy_coords(*coord.linear_to_chimera(v)) for v in G.nodes()}
     else:
         # best case scenario, each node in G has a chimera_index attribute. Otherwise
         # we will try to determine it using the find_chimera_indices function.

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -99,7 +99,7 @@ def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
         else:
             m = G.graph.get('rows')
             coord = pegasus_coordinates(m)
-            pos = {v: xy_coords(*coord.tuple(v)) for v in G.nodes()}
+            pos = {v: xy_coords(*coord.linear_to_pegasus(v)) for v in G.nodes()}
 
     return pos
 

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -415,7 +415,7 @@ class chimera_coordinates(object):
         """Return an iterator converting a sequence of pairs of 4-term Chimera
         coordinates to pairs of linear indices.
         """
-        return self._pair_repack(self.ints, plist)
+        return self._pair_repack(self.iter_chimera_to_linear, plist)
 
     def tuple_pairs(self, plist):
         """Deprecated alias for `iter_linear_to_chimera_pairs`."""
@@ -429,7 +429,7 @@ class chimera_coordinates(object):
         """Return an iterator converting a sequence of pairs of linear indices
         to pairs of 4-term Chimera coordinates.
         """
-        return self._pair_repack(self.tuples, plist)
+        return self._pair_repack(self.iter_linear_to_chimera, plist)
 
 
 def linear_to_chimera(r, m, n=None, t=None):

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -190,7 +190,8 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         if offsets_index != 0:
             raise NotImplementedError("nice coordinate system is only implemented for offsets_index 0")
         labels = 'nice'
-        c2i = get_pegasus_to_nice_fn()
+        p2n = pegasus_coordinates.pegasus_to_nice
+        c2i = lambda *q: p2n(q)
     elif coordinates:
         c2i = lambda *q: q
         labels = 'coordinate'

--- a/dwave_networkx/generators/tests/test_chimera.py
+++ b/dwave_networkx/generators/tests/test_chimera.py
@@ -144,14 +144,14 @@ class TestChimeraGraph(unittest.TestCase):
             q = Gnodes[v]['chimera_index']
             self.assertIn(q, Hnodes)
             self.assertEqual(Hnodes[q]['linear_index'], v)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.chimera_to_linear(q))
+            self.assertEqual(q, coords.linear_to_chimera(v))
         for q in Hnodes:
             v = Hnodes[q]['linear_index']
             self.assertIn(v, Gnodes)
             self.assertEqual(Gnodes[v]['chimera_index'], q)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.chimera_to_linear(q))
+            self.assertEqual(q, coords.linear_to_chimera(v))
 
     def test_coordinate_subgraphs(self):
         from dwave_networkx.generators.chimera import chimera_coordinates
@@ -161,9 +161,9 @@ class TestChimeraGraph(unittest.TestCase):
         coords = chimera_coordinates(4)
 
         lmask = sample(list(G.nodes()), G.number_of_nodes()//2)
-        cmask = list(coords.tuples(lmask))
+        cmask = list(coords.iter_linear_to_chimera(lmask))
 
-        self.assertEqual(lmask, list(coords.ints(cmask)))
+        self.assertEqual(lmask, list(coords.iter_chimera_to_linear(cmask)))
 
         Gm = dnx.chimera_graph(4, node_list=lmask)
         Hm = dnx.chimera_graph(4, node_list=cmask, coordinates=True)
@@ -186,17 +186,17 @@ class TestChimeraGraph(unittest.TestCase):
             q = Gnodes[v]['chimera_index']
             self.assertIn(q, Hnodes)
             self.assertEqual(Hnodes[q]['linear_index'], v)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.chimera_to_linear(q))
+            self.assertEqual(q, coords.linear_to_chimera(v))
         for q in Hnodes:
             v = Hnodes[q]['linear_index']
             self.assertIn(v, Gnodes)
             self.assertEqual(Gnodes[v]['chimera_index'], q)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.chimera_to_linear(q))
+            self.assertEqual(q, coords.linear_to_chimera(v))
 
-        self.assertEqual(EG, sorted(map(sorted, coords.int_pairs(Hn.edges()))))
-        self.assertEqual(EH, sorted(map(sorted, coords.tuple_pairs(Gn.edges()))))
+        self.assertEqual(EG, sorted(map(sorted, coords.iter_chimera_to_linear_pairs(Hn.edges()))))
+        self.assertEqual(EH, sorted(map(sorted, coords.iter_linear_to_chimera_pairs(Gn.edges()))))
 
     def test_linear_to_chimera(self):
         G = dnx.linear_to_chimera(212, 8, 8, 4)

--- a/dwave_networkx/generators/tests/test_pegasus.py
+++ b/dwave_networkx/generators/tests/test_pegasus.py
@@ -76,14 +76,14 @@ class TestPegasusCoordinates(unittest.TestCase):
             q = Gnodes[v]['pegasus_index']
             self.assertIn(q, Hnodes)
             self.assertEqual(Hnodes[q]['linear_index'], v)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.pegasus_to_linear(q))
+            self.assertEqual(q, coords.linear_to_pegasus(v))
         for q in Hnodes:
             v = Hnodes[q]['linear_index']
             self.assertIn(v, Gnodes)
             self.assertEqual(Gnodes[v]['pegasus_index'], q)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.pegasus_to_linear(q))
+            self.assertEqual(q, coords.linear_to_pegasus(v))
 
     def test_nice_coordinates(self):
         G = dnx.pegasus_graph(4, nice_coordinates=True)
@@ -93,10 +93,10 @@ class TestPegasusCoordinates(unittest.TestCase):
                 pg = (t,) + p
                 qg = (t,) + q
                 self.assertTrue(G.has_edge(pg, qg))
-        n2p = get_nice_to_pegasus_fn()
-        p2n = get_pegasus_to_nice_fn()
+        n2p = pegasus_coordinates.nice_to_pegasus
+        p2n = pegasus_coordinates.pegasus_to_nice
         for p in G.nodes():
-            self.assertEqual(p2n(*n2p(*p)), p)
+            self.assertEqual(p2n(n2p(p)), p)
             self.assertTrue(H.has_node(p[1:]))
 
     def test_consistent_linear_nice_pegasus(self):
@@ -158,9 +158,9 @@ class TestPegasusCoordinates(unittest.TestCase):
         coords = pegasus_coordinates(4)
 
         lmask = sample(list(G.nodes()), G.number_of_nodes()//2)
-        cmask = list(coords.tuples(lmask))
+        cmask = list(coords.iter_linear_to_pegasus(lmask))
 
-        self.assertEqual(lmask, list(coords.ints(cmask)))
+        self.assertEqual(lmask, list(coords.iter_pegasus_to_linear(cmask)))
 
         Gm = dnx.pegasus_graph(4, node_list=lmask)
         Hm = dnx.pegasus_graph(4, node_list=cmask, coordinates=True)
@@ -183,17 +183,17 @@ class TestPegasusCoordinates(unittest.TestCase):
             q = Gnodes[v]['pegasus_index']
             self.assertIn(q, Hnodes)
             self.assertEqual(Hnodes[q]['linear_index'], v)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.pegasus_to_linear(q))
+            self.assertEqual(q, coords.linear_to_pegasus(v))
         for q in Hnodes:
             v = Hnodes[q]['linear_index']
             self.assertIn(v, Gnodes)
             self.assertEqual(Gnodes[v]['pegasus_index'], q)
-            self.assertEqual(v, coords.int(q))
-            self.assertEqual(q, coords.tuple(v))
+            self.assertEqual(v, coords.pegasus_to_linear(q))
+            self.assertEqual(q, coords.linear_to_pegasus(v))
 
-        self.assertEqual(EG, sorted(map(sorted, coords.int_pairs(Hn.edges()))))
-        self.assertEqual(EH, sorted(map(sorted, coords.tuple_pairs(Gn.edges()))))
+        self.assertEqual(EG, sorted(map(sorted, coords.iter_pegasus_to_linear_pairs(Hn.edges()))))
+        self.assertEqual(EH, sorted(map(sorted, coords.iter_linear_to_pegasus_pairs(Gn.edges()))))
 
 
 class TestTupleFragmentation(unittest.TestCase):


### PR DESCRIPTION
I got sick of seeing deprecation warnings, so I cleaned out internal functions to avoid them.