### PR TITLE
add overlapped embedding visualization

### DIFF
--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -283,6 +283,11 @@ def draw_chimera_embedding(G, *args, **kwargs):
         in chains, and edges which are neither chain edges nor interactions.
         If unused_color is None, these nodes and edges will not be shown at all.
 
+    overlapped_embedding: boolean (optional, default False)
+        If overlapped_embedding is True, then chains in emb may overlap (contain
+        the same vertices in G), and the drawing will display these overlaps as
+        concentric circles.
+
     kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
        with the exception of the `pos` parameter which is not used by this

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -277,6 +277,11 @@ def draw_pegasus_embedding(G, *args, **kwargs):
         rather than L configuration. Ignored if G was defined with
         nice_coordinates=True.
 
+    overlapped_embedding: boolean (optional, default False)
+        If overlapped_embedding is True, then chains in emb may overlap (contain
+        the same vertices in G), and the drawing will display these overlaps as
+        concentric circles.
+
     kwargs : optional keywords
        See networkx.draw_networkx() for a description of optional keywords,
        with the exception of the `pos` parameter which is not used by this

--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -348,6 +348,9 @@ def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
             for q, label_vars in node_labels.items():
                 x, y = layout[q]
                 # TODO: find a better way of placing labels around the outside of nodes.
+                # Currently, if the graph is resized, labels will appear at a strange distance from the vertices.
+                # To fix this, the "scale" value below, rather than being a fixed constant, should be determined using
+                # both the size of the nodes and the size of the coordinate space of the graph.
                 scale = 0.1
                 # spread the labels evenly around the node.
                 for i, v in enumerate(label_vars):

--- a/dwave_networkx/drawing/tests/test_chimera_layout.py
+++ b/dwave_networkx/drawing/tests/test_chimera_layout.py
@@ -128,3 +128,11 @@ class TestDrawing(unittest.TestCase):
         dnx.draw_chimera_embedding(C, emb)
         dnx.draw_chimera_embedding(C, emb, embedded_graph=G)
         dnx.draw_chimera_embedding(C, emb, interaction_edges=C.edges())
+
+    @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
+    @unittest.skipUnless(_display, " No display found")
+    def test_draw_overlapped_chimera_embedding(self):
+        C = dnx.chimera_graph(2)
+        emb = {0: [1, 5], 1: [5, 9, 13], 2: [25, 29], 3: [17, 21]}
+        dnx.draw_chimera_embedding(C, emb, overlapped_embedding=True)
+        dnx.draw_chimera_embedding(C, emb, overlapped_embedding=True, show_labels=True)

--- a/dwave_networkx/drawing/tests/test_pegasus_layout.py
+++ b/dwave_networkx/drawing/tests/test_pegasus_layout.py
@@ -112,3 +112,11 @@ class TestDrawing(unittest.TestCase):
         dnx.draw_pegasus_embedding(P, emb, embedded_graph=G)
         dnx.draw_pegasus_embedding(P, emb, interaction_edges=P.edges())
         dnx.draw_pegasus_embedding(P, emb, crosses=True)
+
+    @unittest.skipUnless(_numpy and _plt, "No numpy or matplotlib")
+    @unittest.skipUnless(_display, " No display found")
+    def test_draw_overlapped_chimera_embedding(self):
+        C = dnx.pegasus_graph(2)
+        emb = {0: [12, 35], 1: [12, 31], 2: [32], 3: [14]}
+        dnx.draw_pegasus_embedding(C, emb, overlapped_embedding=True)
+        dnx.draw_pegasus_embedding(C, emb, overlapped_embedding=True, show_labels=True)


### PR DESCRIPTION
add an optional overlapped_embedding flag to draw_embedding.

        If overlapped_embedding is True, then chains in emb may overlap (contain
        the same vertices in G), and the drawing will display these overlaps as
        concentric circles.