### PR TITLE
Fix error in QUBO constraint

### DIFF
--- a/dwave_networkx/algorithms/tests/test_tsp.py
+++ b/dwave_networkx/algorithms/tests/test_tsp.py
@@ -215,8 +215,7 @@ class TestTSPQUBO(unittest.TestCase):
     
     def test_weighted_complete_graph(self):
         G = nx.Graph()
-        G.add_weighted_edges_from({(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 2, 3),
-                                   (1, 3, 4), (2, 3, 5)})
+        G.add_weighted_edges_from({(0, 1, 1), (0, 2, 100), (0, 3, 1), (1, 2, 1), (1, 3, 100), (2, 3, 1)})
 
         lagrange = 5.0
 

--- a/dwave_networkx/algorithms/tests/test_tsp.py
+++ b/dwave_networkx/algorithms/tests/test_tsp.py
@@ -212,6 +212,20 @@ class TestTSPQUBO(unittest.TestCase):
             ground_count += 1
 
         self.assertEqual(ground_count, len(min_routes))
+    
+    def test_weighted_complete_graph(self):
+        G = nx.Graph()
+        G.add_weighted_edges_from({(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 2, 3),
+                                   (1, 3, 4), (2, 3, 5)})
+        
+        Q = traveling_salesperson_qubo(G, lagrange, weight)
+
+        N = G.number_of_nodes()
+        correct_sum = G.size(weight)*2*N-2*N*N*lagrange+2*N*N*(N-1)*lagrange)
+
+        actual_sum = sum(Q.values())
+
+        self.assertEqual(correct_sum, actual_sum)
 
     def test_exceptions(self):
         G = nx.Graph([(0, 1)])

--- a/dwave_networkx/algorithms/tests/test_tsp.py
+++ b/dwave_networkx/algorithms/tests/test_tsp.py
@@ -217,11 +217,13 @@ class TestTSPQUBO(unittest.TestCase):
         G = nx.Graph()
         G.add_weighted_edges_from({(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 2, 3),
                                    (1, 3, 4), (2, 3, 5)})
-        
-        Q = traveling_salesperson_qubo(G, lagrange, weight)
+
+        lagrange = 5.0
+
+        Q = tsp.traveling_salesperson_qubo(G, lagrange, 'weight')
 
         N = G.number_of_nodes()
-        correct_sum = G.size(weight)*2*N-2*N*N*lagrange+2*N*N*(N-1)*lagrange)
+        correct_sum = G.size('weight')*2*N-2*N*N*lagrange+2*N*N*(N-1)*lagrange
 
         actual_sum = sum(Q.values())
 

--- a/dwave_networkx/algorithms/tsp.py
+++ b/dwave_networkx/algorithms/tsp.py
@@ -168,7 +168,9 @@ def traveling_salesperson_qubo(G, lagrange=2, weight='weight'):
         for node_1 in G:
             Q[((node_1, pos), (node_1, pos))] -= lagrange
             for node_2 in set(G)-{node_1}:
-                Q[((node_1, pos), (node_2, pos))] += 2.0*lagrange
+                # QUBO coefficient is 2*lagrange, but we are placing this value 
+                # above *and* below the diagonal, so we put half in each position.
+                Q[((node_1, pos), (node_2, pos))] += lagrange
 
     # Objective that minimizes distance
     for u, v in itertools.combinations(G.nodes, 2):


### PR DESCRIPTION
Constraint on lines 170-171 had quadratic coefficient placed both above and below the diagonal.  Corrected error by dividing coefficient by 2.  Added comments for description.

Resolves #145 