### PR TITLE
Reduce warnings in SDK build (for post-unified-docs SDK)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,3 @@
 D-Wave welcomes contributions to Ocean projects.
 
-See how to contribute at :std:doc:`Ocean Contributors <oceandocs:CONTRIBUTING>`.
+See how to contribute at :std:doc:`Ocean Contributors <oceandocs:contributing>`.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@
 .. inclusion-marker-do-not-remove
 
 D-Wave NetworkX
-====================
+===============
+
+.. index-start-marker
 
 D-Wave NetworkX is an extension of `NetworkX <http://networkx.github.io>`_\ ---a
 Python language package for exploration and analysis of networks and network
@@ -25,7 +27,7 @@ Example Usage
 ----------------
 
 This example generates a graph for a Chimera unit cell (eight nodes in a 4-by-2
-bipartite architecture). 
+bipartite architecture).
 
 .. code: python
 
@@ -33,6 +35,8 @@ bipartite architecture).
 >>> graph = dnx.chimera_graph(1, 1, 4)
 
 See the documentation for more examples.
+
+.. index-end-marker
 
 Installation
 ====================

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,7 @@ algorithms---for users of D-Wave Systems. It provides tools for working with
 Chimera graphs and implementations of graph-theory algorithms on the D-Wave
 system and other binary quadratic model samplers.
 
-Example Usage
-----------------
-
-This example generates a graph for a Chimera unit cell (eight nodes in a 4-by-2
+The example below generates a graph for a Chimera unit cell (eight nodes in a 4-by-2
 bipartite architecture).
 
 .. code: python
@@ -39,7 +36,7 @@ See the documentation for more examples.
 .. index-end-marker
 
 Installation
-====================
+============
 
 .. installation-start-marker
 
@@ -59,6 +56,6 @@ Installation
 .. installation-end-marker
 
 License
-====================
+=======
 
 Released under the Apache License 2.0.

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,1 @@
+../README.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'sphinx.ext.ifconfig',
 ]
 
 autosummary_generate = True
@@ -79,7 +80,7 @@ add_module_names = False
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'sdk_index.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -119,7 +120,7 @@ html_static_path = ['_static']
 def setup(app):
     app.add_stylesheet('cookie_notice.css')
     app.add_javascript('cookie_notice.js')
-
+    app.add_config_value('target', 'repo', 'env')
 
 # -- Options for HTMLHelp output ------------------------------------------
 
@@ -202,14 +203,6 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
     'networkx': ('https://networkx.github.io/documentation/stable/', None),
-    'dimod': ('https://docs.ocean.dwavesys.com/projects/dimod/en/latest/', None),
-    'binarycsp': ('https://docs.ocean.dwavesys.com/projects/binarycsp/en/latest/', None),
-    'cloud-client': ('https://docs.ocean.dwavesys.com/projects/cloud-client/en/latest/', None),
-    'neal': ('https://docs.ocean.dwavesys.com/projects/neal/en/latest/', None),
-    'dwave-networkx': ('https://docs.ocean.dwavesys.com/projects/dwave-networkx/en/latest/', None),
-    'system': ('https://docs.ocean.dwavesys.com/projects/system/en/latest/', None),
-    'penaltymodel': ('https://docs.ocean.dwavesys.com/projects/penaltymodel/en/latest/', None),
-    'minorminer': ('https://docs.ocean.dwavesys.com/projects/minorminer/en/latest/', None),
     'qbsolv': ('https://docs.ocean.dwavesys.com/projects/qbsolv/en/latest/', None),
     'oceandocs': ('https://docs.ocean.dwavesys.com/en/latest/', None),
     'sysdocs_gettingstarted': ('https://docs.dwavesys.com/docs/latest/', None)}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 
 .. _index_dnx:
 
-.. include:: ../README.rst
+.. include:: README.rst
   :start-after: inclusion-marker-do-not-remove
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 ..  -*- coding: utf-8 -*-
 
-.. _contents:
+.. _index_dnx:
 
 .. include:: ../README.rst
   :start-after: inclusion-marker-do-not-remove
@@ -21,7 +21,7 @@ Documentation
    intro
    reference/index
    bibliography
-   
+
 .. sdk-end-marker
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,4 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-* :ref:`glossary`
+* `Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,6 @@
 Installation
 ================
 
-.. include::  ../README.rst
+.. include::  README.rst
    :start-after: installation-start-marker
    :end-before: installation-end-marker

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,4 +1,4 @@
 License
 =========
 
-.. include:: ../LICENSE.txt
+.. include:: LICENSE.txt

--- a/docs/reference/algorithms/index.rst
+++ b/docs/reference/algorithms/index.rst
@@ -1,4 +1,4 @@
-.. _algorithms:
+.. _algorithms_dnx:
 
 **********
 Algorithms

--- a/docs/reference/default_sampler.rst
+++ b/docs/reference/default_sampler.rst
@@ -1,4 +1,4 @@
-.. _default_sampler:
+.. _default_sampler_dnx:
 
 Default sampler
 ***************

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -1,4 +1,4 @@
-.. _generators:
+.. _generators_dnx:
 
 Graph Generators
 ****************

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,4 +1,4 @@
-.. _reference:
+.. _reference_dnx:
 
 Reference Documentation
 *************************

--- a/docs/sdk_index.rst
+++ b/docs/sdk_index.rst
@@ -4,7 +4,7 @@
 dwave-networkx
 ==============
 
-.. include:: /readmes/dnx.rst
+.. include:: README.rst
    :start-after: index-start-marker
    :end-before: index-end-marker
 

--- a/docs/sdk_index.rst
+++ b/docs/sdk_index.rst
@@ -1,8 +1,12 @@
-.. _sdk_index:
+.. _sdk_index_dnx:
 
 ==============
 dwave-networkx
 ==============
+
+.. include:: /readmes/dnx.rst
+   :start-after: index-start-marker
+   :end-before: index-end-marker
 
 .. include:: index.rst
    :start-after: sdk-start-marker


### PR DESCRIPTION
Not to be deployed yet. Should fix build warnings on duplicate labels and intersphinx links.