### PR TITLE
fix double axes bug

### DIFF
--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -97,7 +97,7 @@ def draw_qubit_graph(G, layout, linear_biases={}, quadratic_biases={},
         _mpl_toolkit_found = True
 
     fig = plt.gcf()
-    ax = kwargs.pop('ax', plt.gca())
+    ax = kwargs.pop('ax', None)
     cax = kwargs.pop('cax', None)
 
     if linear_biases or quadratic_biases:


### PR DESCRIPTION
 when evaluating the kwargs.pop even if the existing element is chosen, the fail statement is executed. in this specific example, when 'ax' is sent as None, it will be evaluated to None while still creating a new axis under fig by running the plt.gca() command. The case of ax=None is already handled under the if statements, even though they are very ugly (hardcoded) to make the plots look pretty