### PR TITLE
Fix canonical_chimera_labeling to correctly choose a root in a corner

### DIFF
--- a/dwave_networkx/algorithms/canonicalization.py
+++ b/dwave_networkx/algorithms/canonicalization.py
@@ -50,7 +50,12 @@ def canonical_chimera_labeling(G, t=None):
     chimera_indices = {}
 
     row = col = 0
-    root = min(adj, key=lambda v: len(adj[v]))
+
+    # need to find a node in a corner
+    root_edge = min(((u, v) for u in adj for v in adj[u]),
+                    key=lambda edge: len(adj[edge[0]]) + len(adj[edge[1]]))
+    root, _ = root_edge
+
     horiz, verti = rooted_tile(adj, root, t)
     while len(chimera_indices) < len(adj):
 

--- a/dwave_networkx/algorithms/tests/test_canonicalization.py
+++ b/dwave_networkx/algorithms/tests/test_canonicalization.py
@@ -103,6 +103,19 @@ class TestCanonicalChimeraLabeling(unittest.TestCase):
 
         self.assertEqual(bqm, bqm2)
 
+    def test_reversed(self):
+        C33 = nx.OrderedGraph()
+        C33.add_nodes_from(reversed(range(3*3*4)))
+        C33.add_edges_from(dnx.chimera_graph(3, 3, 4).edges)
+        coord = chimera_coordinates(3, 3, 4)
+
+        labels = canonical_chimera_labeling(C33)
+        labels = {v: coord.chimera_to_linear(labels[v]) for v in labels}
+
+        G = nx.relabel_nodes(C33, labels, copy=True)
+
+        self.assertTrue(nx.is_isomorphic(G, C33))
+
     def test__shore_size_tiles(self):
         for t in range(1, 8):
             G = dnx.chimera_graph(1, 1, t)


### PR DESCRIPTION
Should resolve the broken tests in https://github.com/dwavesystems/dwave-hybrid/pull/222