### PR TITLE
Fix rotation of TSP route to have start in the beginning

### DIFF
--- a/dwave_networkx/algorithms/tests/test_tsp.py
+++ b/dwave_networkx/algorithms/tests/test_tsp.py
@@ -95,9 +95,9 @@ class TestTSP(unittest.TestCase):
         G.add_weighted_edges_from((u, v, .5)
                                   for u, v in itertools.combinations(range(3), 2))
 
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), start=2)
+        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), start=1)
 
-        self.assertEqual(route[0], 2)
+        self.assertEqual(route[0], 1)
 
 
 class TestTSPQUBO(unittest.TestCase):

--- a/dwave_networkx/algorithms/tsp.py
+++ b/dwave_networkx/algorithms/tsp.py
@@ -109,7 +109,7 @@ def traveling_salesperson(G, sampler=None, lagrange=None, weight='weight',
     if start is not None and route[0] != start:
         # rotate to put the start in front
         idx = route.index(start)
-        route = route[-idx:] + route[:-idx]
+        route = route[idx:] + route[:idx]
 
     return route
 


### PR DESCRIPTION
This PR fixes #171 .

I first update the test case so that it catches the original bug reported in #171 and then implement the proposed solution from #171 .
