### PR TITLE
Remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ readme = {file = "README.rst", content-type = "text/x-rst"}
 license = "Apache-2.0"
 license-files = ["LICEN[CS]E*"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Setuptools>=77 now raises
```
setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). Please remove:

      License :: OSI Approved :: Apache Software License
```
since its deprecation. See [PEP 639](https://peps.python.org/pep-0639) and [#4833](https://github.com/pypa/setuptools/pull/4833) for details.