### PR TITLE
Use problem generators from dimod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,15 +229,9 @@ workflows:
           matrix:
             parameters:
               python-version: &python-versions ["3.10", "3.11", "3.12", "3.13", "3.14"]
-              dependency-versions: [&dependencies-oldest "dimod==0.12.16 networkx==3.2 numpy==2",
+              dependency-versions: [&dependencies-oldest "dimod==0.12.22 networkx==3.2 numpy==2",
                                     &dependencies-latest "dimod networkx numpy",
                                     ]
-            exclude:
-              # dimod < 0.12.17 not supported on py313+
-              - python-version: "3.13"
-                dependency-versions: *dependencies-oldest
-              - python-version: "3.14"
-                dependency-versions: *dependencies-oldest
 
       - test-osx:
           matrix:

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -231,14 +231,6 @@ its member pairs.
     maximum_independent_set
     is_independent_set
 
-Helper Functions
-----------------
-
-.. autosummary::
-    :toctree: generated/
-
-    maximum_weighted_independent_set_qubo
-
 .. _graphs_partitioning:
 
 Partitioning

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -277,7 +277,6 @@ friendly/hostile interactions between vertices.
     :toctree: generated/
 
     structural_imbalance
-    structural_imbalance_ising
 
 .. _graphs_traveling_salesperson:
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -300,4 +300,4 @@ weighted graph.
     :toctree: generated/
 
     traveling_salesperson
-    traveling_salesperson_qubo
+    is_hamiltonian_path

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -169,9 +169,7 @@ A matching is a subset of graph edges in which no vertex occurs more than once.
 .. autosummary::
     :toctree: generated/
 
-    matching_bqm
-    maximal_matching_bqm
-    min_maximal_matching_bqm
+    maximal_matching
     min_maximal_matching
 
 .. _graphs_maximum_cut:

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -74,9 +74,7 @@ The map-coloring problem is to assign a color to each region of a map
 
     is_vertex_coloring
     min_vertex_color
-    min_vertex_color_qubo
     vertex_color
-    vertex_color_qubo
 
 .. _graphs_cover:
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -9,6 +9,13 @@ binary quadratic model samplers.
 
 .. currentmodule:: dwave.graphs
 
+
+.. note::
+    Some of the algorithms below are implemented by sampling from a binary
+    quadratic model. Note that samplers by their nature may not return the
+    optimal solution. The functions that use a sampler do not attempt to confirm
+    the quality of the returned solution.
+
 .. _graphs_canonicalization:
 
 Canonicalization

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -147,7 +147,6 @@ Markov Networks
     :toctree: generated/
 
     sample_markov_network
-    markov_network_bqm
 
 .. _graphs_matching:
 

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -22,19 +22,17 @@ from dimod.typing import GraphLike
 
 __all__ = ["is_cycle",
            "is_vertex_coloring",
-           "min_vertex_color",
-           "min_vertex_coloring",   # alias for min_vertex_color
-           "vertex_color",
-           "vertex_coloring",       # alias for vertex_color
+           "min_vertex_coloring",
+           "vertex_coloring",
            ]
 
 
 @graph_argument('graph')
-def vertex_color(graph: GraphLike,
-                 colors: int | Sequence[Hashable],
-                 sampler: dimod.Sampler,
-                 **sampler_args,
-                 ) -> dict[Hashable, Hashable]:
+def vertex_coloring(graph: GraphLike,
+                    colors: int | Sequence[Hashable],
+                    sampler: dimod.Sampler,
+                    **sampler_args,
+                    ) -> dict[Hashable, Hashable]:
     """Returns an approximate vertex coloring.
 
     Vertex coloring is the problem of assigning a color to the vertices of a
@@ -77,16 +75,12 @@ def vertex_color(graph: GraphLike,
     return {v: c for (v, c), val in sample.items() if val}
 
 
-# alias
-vertex_coloring = vertex_color 
-
-
-def min_vertex_color(graph: nx.Graph,
-                     sampler: dimod.Sampler,
-                     chromatic_lb: int | None = None,
-                     chromatic_ub: int | None = None,
-                     **sampler_args
-                     ) -> dict[Hashable, Hashable]:
+def min_vertex_coloring(graph: nx.Graph,
+                        sampler: dimod.Sampler,
+                        chromatic_lb: int | None = None,
+                        chromatic_ub: int | None = None,
+                        **sampler_args
+                        ) -> dict[Hashable, Hashable]:
     """Returns an approximate minimum vertex coloring.
 
     Vertex coloring is the problem of assigning a color to the
@@ -127,10 +121,6 @@ def min_vertex_color(graph: nx.Graph,
     sample = sampler.sample(bqm, **sampler_args).first.sample
 
     return {v: c for (v, c), val in sample.items() if val}
-
-
-# alias
-min_vertex_coloring = min_vertex_color
 
 
 def is_cycle(graph: nx.Graph) -> bool:

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -12,72 +12,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import math
-import itertools
+import dimod
 
-import networkx as nx
-
-__all__ = ["is_vertex_coloring",
-           "is_cycle",
+__all__ = ["is_cycle",
+           "is_vertex_coloring",
            "min_vertex_color",
-           "min_vertex_coloring",  # alias for min_vertex_color
-           "min_vertex_color_qubo",
+           "min_vertex_coloring",   # alias for min_vertex_color
            "vertex_color",
-           "vertex_color_qubo",
+           "vertex_coloring",       # alias for vertex_color
            ]
-
-
-@nx.utils.decorators.nodes_or_number(1)
-def vertex_color_qubo(G, colors):
-    """Return the QUBO with ground states corresponding to a vertex coloring.
-
-    If `V` is the set of nodes, `E` is the set of edges and `C` is the set of
-    colors the resulting qubo will have:
-
-    * :math:`|V|*|C|` variables/nodes
-    * :math:`|V|*|C|*(|C| - 1) / 2 + |E|*|C|` interactions/edges
-
-    The QUBO has ground energy :math:`-|V|` and an infeasible gap of 1.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum vertex coloring.
-
-    colors : int/sequence
-        The colors. If an int, the colors are labelled `[0, n)`. The number of
-        colors must be greater or equal to the chromatic number of the graph.
-
-    Returns
-    -------
-    QUBO : dict
-        The QUBO with ground states corresponding to valid colorings of the
-        graph. The QUBO variables are labelled `(v, c)` where `v` is a node
-        in `G` and `c` is a color. In the ground state of the QUBO, a variable
-        `(v, c)` has value 1 if `v` should be colored `c` in a valid coloring.
-
-
-    """
-    _, colors = colors
-
-    Q = {}
-
-    # enforce that each variable in G has at most one color
-    for v in G.nodes:
-        # 1 in k constraint
-        for c in colors:
-            Q[(v, c), (v, c)] = -1
-
-        for c0, c1 in itertools.combinations(colors, 2):
-            Q[(v, c0), (v, c1)] = 2
-
-    # enforce that adjacent nodes do not have the same color
-    for u, v in G.edges:
-        # NAND constraint
-        for c in colors:
-            Q[(u, c), (v, c)] = 1
-
-    return Q
 
 
 def vertex_color(G, colors, sampler, **sampler_args):
@@ -118,128 +61,16 @@ def vertex_color(G, colors, sampler, **sampler_args):
     sample.
 
     """
-    Q = vertex_color_qubo(G, colors)
+    bqm = dimod.generators.vertex_coloring(G, colors)
 
     # get the lowest energy sample
-    sample = sampler.sample_qubo(Q, **sampler_args).first.sample
+    sample = sampler.sample(bqm, **sampler_args).first.sample
 
     return {v: c for (v, c), val in sample.items() if val}
 
 
-def _chromatic_number_upper_bound(G):
-    # tries to determine an upper bound on the chromatic number of G
-    # Assumes G is not complete
-
-    if not nx.is_connected(G):
-        return max((_chromatic_number_upper_bound(G.subgraph(c))
-                    for c in nx.connected_components(G)))
-
-    n_nodes = len(G.nodes)
-    n_edges = len(G.edges)
-
-    # chi * (chi - 1) <= 2 * |E|
-    quad_bound = math.ceil((1 + math.sqrt(1 + 8 * n_edges)) / 2)
-
-    if n_nodes % 2 == 1 and is_cycle(G):
-        # odd cycle graphs need three colors
-        bound = 3
-    elif n_nodes > 2:
-        try:
-            import numpy as np
-        except ImportError:
-            # chi <= max degree, unless it is complete or a cycle graph of odd length,
-            # in which case chi <= max degree + 1 (Brook's Theorem)
-            bound = max(G.degree(node) for node in G)
-        else:
-            # Let A be the adj matrix of G (symmetric, 0 on diag). Let theta_1
-            # be the largest eigenvalue of A. Then chi <= theta_1 + 1 with
-            # equality iff G is complete or an odd cycle.
-            # this is strictly better than brooks theorem
-            # G is real symmetric, use eigvalsh for real valued output.
-            bound = math.ceil(max(np.linalg.eigvalsh(nx.to_numpy_array(G))))
-    else:
-        # we know it's connected
-        bound = n_nodes
-
-    return min(quad_bound, bound)
-
-
-def _chromatic_number_lower_bound(G):
-    # find a random maximal clique and use that to determine a lower bound
-    v = max(G, key=G.degree)
-
-    clique = {v}
-    for u in G[v]:
-        if all(w in G[u] for w in clique):
-            clique.add(u)
-
-    return len(clique)
-
-
-def min_vertex_color_qubo(G, chromatic_lb=None, chromatic_ub=None):
-    """Return a QUBO with ground states corresponding to a minimum vertex
-    coloring.
-
-    Vertex coloring is the problem of assigning a color to the
-    vertices of a graph in a way that no adjacent vertices have the
-    same color. A minimum vertex coloring is the problem of solving
-    the vertex coloring problem using the smallest number of colors.
-
-    Defines a QUBO [Dah2013]_ with ground states corresponding to minimum
-    vertex colorings and uses the sampler to sample from it.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum vertex coloring.
-
-    chromatic_lb : int, optional
-         A lower bound on the chromatic number. If one is not provided, a
-         bound is calulcated.
-
-    chromatic_ub : int, optional
-        An upper bound on the chromatic number. If one is not provided, a bound
-        is calculated.
-
-    Returns
-    -------
-    QUBO : dict
-        The QUBO with ground states corresponding to minimum colorings of the
-        graph. The QUBO variables are labelled `(v, c)` where `v` is a node
-        in `G` and `c` is a color. In the ground state of the QUBO, a variable
-        `(v, c)` has value 1 if `v` should be colored `c` in a valid coloring.
-
-    """
-
-    chi_ub = _chromatic_number_upper_bound(G)
-    chromatic_ub = chi_ub if chromatic_ub is None else min(chi_ub, chromatic_ub)
-
-    chib_lb = _chromatic_number_lower_bound(G)
-    chromatic_lb = chib_lb if chromatic_lb is None else max(chib_lb, chromatic_lb)
-
-    if chromatic_lb > chromatic_ub:
-        raise RuntimeError("something went wrong when calculating the "
-                           "chromatic number bounds")
-
-    # our base QUBO is one with as many colors as we might need, so we use the
-    # upper bound
-    Q = vertex_color_qubo(G, int(chromatic_ub))
-
-    if chromatic_lb != chromatic_ub:
-        # we want to penalize the colors that we aren't sure that we need
-        # we might need to use some of the colors, so we want to penalize
-        # them in increasing amounts, linearly.
-
-        num_penalized = chromatic_ub - chromatic_lb
-
-        # we want evenly spaced penalties in (0, 1) without the endpoints
-        weights = [p / (num_penalized + 1) for p in range(1, num_penalized + 1)]
-
-        for p, c in zip(weights, range(chromatic_lb, chromatic_ub)):
-            for v in G:
-                Q[(v, c), (v, c)] += p
-
-    return Q
+# alias
+vertex_coloring = vertex_color
 
 
 def min_vertex_color(G, sampler, chromatic_lb=None, chromatic_ub=None, **sampler_args):
@@ -286,16 +117,16 @@ def min_vertex_color(G, sampler, chromatic_lb=None, chromatic_ub=None, **sampler
 
     """
 
-    Q = min_vertex_color_qubo(G, chromatic_lb=chromatic_lb,
-                              chromatic_ub=chromatic_ub)
+    bqm = dimod.generators.min_vertex_coloring(
+        G, chromatic_lb=chromatic_lb, chromatic_ub=chromatic_ub)
 
     # get the lowest energy sample
-    sample = sampler.sample_qubo(Q, **sampler_args).first.sample
+    sample = sampler.sample(bqm, **sampler_args).first.sample
 
     return {v: c for (v, c), val in sample.items() if val}
 
 
-# legacy name, alias
+# alias
 min_vertex_coloring = min_vertex_color
 
 

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -64,10 +64,6 @@ def vertex_color(graph: GraphLike,
         A coloring for each vertex in ``graph`` such that no adjacent nodes share
         the same color. A dict of the form ``{node: color, ...}``.
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     """
     if not isinstance(colors, Sequence):
         # assume colors is Integral
@@ -122,10 +118,6 @@ def min_vertex_color(graph: nx.Graph,
     Returns:
         A coloring for each vertex in ``graph`` such that no adjacent nodes
         share the same color. A dict of the form ``{node: color, ...}``.
-
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
 
     """
     bqm = dimod.generators.min_vertex_coloring(

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -12,7 +12,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from collections.abc import Sequence, Hashable
+
 import dimod
+import networkx as nx
+
+from dimod.decorators import graph_argument
+from dimod.typing import GraphLike
 
 __all__ = ["is_cycle",
            "is_vertex_coloring",
@@ -23,45 +29,51 @@ __all__ = ["is_cycle",
            ]
 
 
-def vertex_color(G, colors, sampler, **sampler_args):
+@graph_argument('graph')
+def vertex_color(graph: GraphLike,
+                 colors: int | Sequence[Hashable],
+                 sampler: dimod.Sampler,
+                 **sampler_args,
+                 ) -> dict[Hashable, Hashable]:
     """Returns an approximate vertex coloring.
 
-    Vertex coloring is the problem of assigning a color to the
-    vertices of a graph in a way that no adjacent vertices have the
-    same color.
+    Vertex coloring is the problem of assigning a color to the vertices of a
+    graph in a way that no adjacent vertices have the same color.
 
-    Defines a QUBO [Dah2013]_ with ground states corresponding to valid
+    Defines a binary quadratic model with ground states corresponding to valid
     vertex colorings and uses the sampler to sample from it.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum vertex coloring.
+    Args:
+        graph:
+            The graph on which to find a vertex coloring. Either an integer
+            ``n``, interpreted as a complete graph of size ``n``, a nodes/edges
+            pair, a list of edges or a NetworkX graph.
 
-    colors : int/sequence
-        The colors. If an int, the colors are labelled `[0, n)`. The number of
-        colors must be greater or equal to the chromatic number of the graph.
+        colors:
+            The colors. If an int, the colors are labelled ``[0, n)``. The
+            number of colors must be greater or equal to the chromatic number of
+            the graph.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+        sampler_args:
+            Additional keyword parameters are passed to the sampler.
 
-    Returns
-    -------
-    coloring : dict
-        A coloring for each vertex in G such that no adjacent nodes
-        share the same color. A dict of the form {node: color, ...}
+    Returns:
+        A coloring for each vertex in graph such that no adjacent nodes share
+        the same color. A dict of the form ``{node: color, ...}``.
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
     """
-    bqm = dimod.generators.vertex_coloring(G, colors)
+    if not isinstance(colors, Sequence):
+        # assume colors is Integral
+        colors = range(int(colors))
+
+    bqm = dimod.generators.vertex_coloring(graph, colors)
 
     # get the lowest energy sample
     sample = sampler.sample(bqm, **sampler_args).first.sample
@@ -70,10 +82,15 @@ def vertex_color(G, colors, sampler, **sampler_args):
 
 
 # alias
-vertex_coloring = vertex_color
+vertex_coloring = vertex_color 
 
 
-def min_vertex_color(G, sampler, chromatic_lb=None, chromatic_ub=None, **sampler_args):
+def min_vertex_color(graph: nx.Graph,
+                     sampler: dimod.Sampler,
+                     chromatic_lb: int | None = None,
+                     chromatic_ub: int | None = None,
+                     **sampler_args
+                     ) -> dict[Hashable, Hashable]:
     """Returns an approximate minimum vertex coloring.
 
     Vertex coloring is the problem of assigning a color to the
@@ -81,44 +98,38 @@ def min_vertex_color(G, sampler, chromatic_lb=None, chromatic_ub=None, **sampler
     same color. A minimum vertex coloring is the problem of solving
     the vertex coloring problem using the smallest number of colors.
 
-    Defines a QUBO [Dah2013]_ with ground states corresponding to minimum
+    Defines a binary quadratic model with ground states corresponding to minimum
     vertex colorings and uses the sampler to sample from it.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum vertex coloring.
+    Args:
+        graph:
+            The graph on which to find a minimum vertex coloring.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    chromatic_lb : int, optional
-         A lower bound on the chromatic number. If one is not provided, a
-         bound is calculated.
+        chromatic_lb:
+            A lower bound on the chromatic number. If one is not provided, a
+            bound is calculated.
 
-    chromatic_ub : int, optional
-        An upper bound on the chromatic number. If one is not provided, a bound
-        is calculated.
+        chromatic_ub:
+            An upper bound on the chromatic number. If one is not provided, a
+            bound is calculated.
 
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+        sampler_args:
+            Additional keyword parameters are passed to the sampler.
 
-    Returns
-    -------
-    coloring : dict
-        A coloring for each vertex in G such that no adjacent nodes
-        share the same color. A dict of the form {node: color, ...}
+    Returns:
+        A coloring for each vertex in ``graph`` such that no adjacent nodes
+        share the same color. A dict of the form ``{node: color, ...}``.
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
     """
-
     bqm = dimod.generators.min_vertex_coloring(
-        G, chromatic_lb=chromatic_lb, chromatic_ub=chromatic_ub)
+        graph, chromatic_lb=chromatic_lb, chromatic_ub=chromatic_ub)
 
     # get the lowest energy sample
     sample = sampler.sample(bqm, **sampler_args).first.sample
@@ -130,20 +141,17 @@ def min_vertex_color(G, sampler, chromatic_lb=None, chromatic_ub=None, **sampler
 min_vertex_coloring = min_vertex_color
 
 
-def is_cycle(G):
+def is_cycle(G: nx.Graph) -> bool:
     """Determines whether the given graph is a cycle or circle graph.
 
     A cycle graph or circular graph is a graph that consists of a single cycle.
 
     https://en.wikipedia.org/wiki/Cycle_graph
 
-    Parameters
-    ----------
-    G : NetworkX graph
+    Args:
+        G: The graph to examine.
 
-    Returns
-    -------
-    is_cycle : bool
+    Returns:
         True if the graph consists of a single cycle.
 
     """
@@ -175,38 +183,34 @@ def is_cycle(G):
     return n_visited == len(G)
 
 
-def is_vertex_coloring(G, coloring):
+def is_vertex_coloring(G: nx.Graph, coloring: dict[Hashable, Hashable]) -> bool:
     """Determines whether the given coloring is a vertex coloring of graph G.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which the vertex coloring is applied.
+    Args:
+        G:
+            The graph on which the vertex coloring is applied.
 
-    coloring : dict
-        A coloring of the nodes of G. Should be a dict of the form
-        {node: color, ...}.
+        coloring:
+            A coloring of the nodes of G. Should be a dict of the form
+            ``{node: color, ...}``.
 
-    Returns
-    -------
-    is_vertex_coloring : bool
+    Returns:
         True if the given coloring defines a vertex coloring; that is, no
         two adjacent vertices share a color.
 
-    Example
-    -------
-    This example colors checks two colorings for a graph, G, of a single Chimera
-    unit cell. The first uses one color (0) for the four horizontal qubits
-    and another (1) for the four vertical qubits, in which case there are
-    no adjacencies; the second coloring swaps the color of one node.
+    Example:
+        This example colors checks two colorings for a graph, G, of a single
+        Chimera unit cell. The first uses one color (0) for the four horizontal
+        qubits and another (1) for the four vertical qubits, in which case there
+        are no adjacencies; the second coloring swaps the color of one node.
 
-    >>> G = dwave.graphs.chimera_graph(1,1,4)
-    >>> colors = {0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
-    >>> dwave.graphs.is_vertex_coloring(G, colors)
-    True
-    >>> colors[4]=0
-    >>> dwave.graphs.is_vertex_coloring(G, colors)
-    False
+        >>> G = dwave.graphs.chimera_graph(1,1,4)
+        >>> colors = {0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
+        >>> dwave.graphs.is_vertex_coloring(G, colors)
+        True
+        >>> colors[4]=0
+        >>> dwave.graphs.is_vertex_coloring(G, colors)
+        False
 
-   """
+    """
     return all(coloring[u] != coloring[v] for u, v in G.edges)

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -141,7 +141,7 @@ def min_vertex_color(graph: nx.Graph,
 min_vertex_coloring = min_vertex_color
 
 
-def is_cycle(G: nx.Graph) -> bool:
+def is_cycle(graph: nx.Graph) -> bool:
     """Determines whether the given graph is a cycle or circle graph.
 
     A cycle graph or circular graph is a graph that consists of a single cycle.
@@ -149,23 +149,23 @@ def is_cycle(G: nx.Graph) -> bool:
     https://en.wikipedia.org/wiki/Cycle_graph
 
     Args:
-        G: The graph to examine.
+        graph: The graph to examine.
 
     Returns:
         True if the graph consists of a single cycle.
 
     """
-    if len(G) <= 2:
+    if len(graph) <= 2:
         return False
 
-    trailing, leading = next(iter(G.edges))
+    trailing, leading = next(iter(graph.edges))
     start_node = trailing
 
     # travel around the graph, checking that each node has degree exactly two
     # also track how many nodes were visited
     n_visited = 1
     while leading != start_node:
-        neighbors = G[leading]
+        neighbors = graph[leading]
 
         if len(neighbors) != 2:
             return False
@@ -180,18 +180,18 @@ def is_cycle(G: nx.Graph) -> bool:
         n_visited += 1
 
     # if we haven't visited all of the nodes, then it is not a connected cycle
-    return n_visited == len(G)
+    return n_visited == len(graph)
 
 
-def is_vertex_coloring(G: nx.Graph, coloring: dict[Hashable, Hashable]) -> bool:
+def is_vertex_coloring(graph: nx.Graph, coloring: dict[Hashable, Hashable]) -> bool:
     """Determines whether the given coloring is a vertex coloring of graph G.
 
     Args:
-        G:
+        graph:
             The graph on which the vertex coloring is applied.
 
         coloring:
-            A coloring of the nodes of ``G``. Should be a dict of the form
+            A coloring of the nodes of ``graph``. Should be a dict of the form
             ``{node: color, ...}``.
 
     Returns:
@@ -199,18 +199,19 @@ def is_vertex_coloring(G: nx.Graph, coloring: dict[Hashable, Hashable]) -> bool:
         two adjacent vertices share a color.
 
     Example:
-        This example colors checks two colorings for a graph, G, of a single
-        Chimera unit cell. The first uses one color (0) for the four horizontal
-        qubits and another (1) for the four vertical qubits, in which case there
-        are no adjacencies; the second coloring swaps the color of one node.
+        This example colors checks two colorings for a graph, ``graph``, of a
+        single Chimera unit cell. The first uses one color (0) for the four
+        horizontal qubits and another (1) for the four vertical qubits, in which
+        case there are no adjacencies; the second coloring swaps the color of
+        one node.
 
-        >>> G = dwave.graphs.chimera_graph(1,1,4)
+        >>> graph = dwave.graphs.chimera_graph(1,1,4)
         >>> colors = {0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
-        >>> dwave.graphs.is_vertex_coloring(G, colors)
+        >>> dwave.graphs.is_vertex_coloring(graph, colors)
         True
         >>> colors[4]=0
-        >>> dwave.graphs.is_vertex_coloring(G, colors)
+        >>> dwave.graphs.is_vertex_coloring(graph, colors)
         False
 
     """
-    return all(coloring[u] != coloring[v] for u, v in G.edges)
+    return all(coloring[u] != coloring[v] for u, v in graph.edges)

--- a/dwave/graphs/algorithms/coloring.py
+++ b/dwave/graphs/algorithms/coloring.py
@@ -61,7 +61,7 @@ def vertex_color(graph: GraphLike,
             Additional keyword parameters are passed to the sampler.
 
     Returns:
-        A coloring for each vertex in graph such that no adjacent nodes share
+        A coloring for each vertex in ``graph`` such that no adjacent nodes share
         the same color. A dict of the form ``{node: color, ...}``.
 
     Note:
@@ -191,7 +191,7 @@ def is_vertex_coloring(G: nx.Graph, coloring: dict[Hashable, Hashable]) -> bool:
             The graph on which the vertex coloring is applied.
 
         coloring:
-            A coloring of the nodes of G. Should be a dict of the form
+            A coloring of the nodes of ``G``. Should be a dict of the form
             ``{node: color, ...}``.
 
     Returns:

--- a/dwave/graphs/algorithms/independent_set.py
+++ b/dwave/graphs/algorithms/independent_set.py
@@ -12,8 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from dimod.generators.graph import (
+    maximum_weight_independent_set as maximum_weight_independent_set_bqm)
+
 __all__ = ["maximum_weighted_independent_set",
-           "maximum_weighted_independent_set_qubo",
            "maximum_independent_set",
            "is_independent_set",
            ]
@@ -22,9 +24,10 @@ __all__ = ["maximum_weighted_independent_set",
 def maximum_weighted_independent_set(G, sampler, weight=None, lagrange=2.0, **sampler_args):
     """Returns an approximate maximum weighted independent set.
 
-    Defines a QUBO with ground states corresponding to a
-    maximum weighted independent set and uses the sampler to sample
-    from it.
+    Defines a binary quadratic model with ground states corresponding to a
+    maximum weighted independent set (see
+    :func:`dimod.generators.maximum_weight_independent_set`) and uses the
+    sampler to sample from it.
 
     An independent set is a set of nodes such that the subgraph
     of G induced by these nodes contains no edges. A maximum
@@ -73,11 +76,13 @@ def maximum_weighted_independent_set(G, sampler, weight=None, lagrange=2.0, **sa
     Frontiers in Physics, Volume 2, Article 5.
 
     """
-    # Get a QUBO representation of the problem
-    Q = maximum_weighted_independent_set_qubo(G, weight, lagrange)
+    # Get a BQM representation of the problem
+    bqm = maximum_weight_independent_set_bqm(G.edges,
+                                             G.nodes(data=weight, default=1),
+                                             strength_multiplier=lagrange)
 
     # use the sampler to find low energy states
-    response = sampler.sample_qubo(Q, **sampler_args)
+    response = sampler.sample(bqm, **sampler_args)
 
     # we want the lowest energy sample
     sample = next(iter(response))
@@ -186,62 +191,3 @@ def is_independent_set(G, indep_nodes):
 
     """
     return len(G.subgraph(indep_nodes).edges) == 0
-
-
-def maximum_weighted_independent_set_qubo(G, weight=None, lagrange=2.0):
-    """Return the QUBO with ground states corresponding to a maximum weighted independent set.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-
-    weight : string, optional (default None)
-        If None, every node has equal weight. If a string, use this node
-        attribute as the node weight. A node without this attribute is
-        assumed to have max weight.
-        
-    lagrange : optional (default 2)
-        Lagrange parameter to weight constraints (no edges within set) 
-        versus objective (largest set possible).
-
-    Returns
-    -------
-    QUBO : dict
-       The QUBO with ground states corresponding to a maximum weighted independent set.
-
-    Examples
-    --------
-
-    >>> from dwave.graphs.algorithms.independent_set import maximum_weighted_independent_set_qubo
-    ...
-    >>> G = nx.path_graph(3)
-    >>> Q = maximum_weighted_independent_set_qubo(G, weight='weight', lagrange=2.0)
-    >>> Q[(0, 0)]
-    -1.0
-    >>> Q[(1, 1)]
-    -1.0
-    >>> Q[(0, 1)]
-    2.0
-
-    """
-
-    # empty QUBO for an empty graph
-    if not G:
-        return {}
-
-    # We assume that the sampler can handle an unstructured QUBO problem, so let's set one up.
-    # Let us define the largest independent set to be S.
-    # For each node n in the graph, we assign a boolean variable v_n, where v_n = 1 when n
-    # is in S and v_n = 0 otherwise.
-    # We call the matrix defining our QUBO problem Q.
-    # On the diagnonal, we assign the linear bias for each node to be the negative of its weight.
-    # This means that each node is biased towards being in S. Weights are scaled to a maximum of 1.
-    # Negative weights are considered 0.
-    # On the off diagnonal, we assign the off-diagonal terms of Q to be 2. Thus, if both
-    # nodes are in S, the overall energy is increased by 2.
-    cost = dict(G.nodes(data=weight, default=1))
-    scale = max(cost.values())
-    Q = {(node, node): min(-cost[node] / scale, 0.0) for node in G}
-    Q.update({edge: lagrange for edge in G.edges})
-
-    return Q

--- a/dwave/graphs/algorithms/markov.py
+++ b/dwave/graphs/algorithms/markov.py
@@ -14,7 +14,8 @@
 
 import dimod
 
-__all__ = ['sample_markov_network', 'markov_network_bqm']
+__all__ = ['sample_markov_network',
+           ]
 
 
 ###############################################################################
@@ -56,8 +57,8 @@ def sample_markov_network(MN, sampler, fixed_variables=None,
 
     Parameters
     ----------
-    G : NetworkX graph
-        A Markov Network as returned by :func:`.markov_network`
+    MN : NetworkX graph
+        A Markov network as returned by :func:`~dwave.graphs.generators.markov.markov_network`
 
     sampler : :class:`dimod.Sampler`
         A dimod sampler.
@@ -127,7 +128,7 @@ def sample_markov_network(MN, sampler, fixed_variables=None,
 
     """
 
-    bqm = markov_network_bqm(MN)
+    bqm = dimod.generators.markov_network(MN)
 
     if fixed_variables:
         # we can modify in-place since we just made it
@@ -143,60 +144,3 @@ def sample_markov_network(MN, sampler, fixed_variables=None,
         return sampleset
     else:
         return list(map(dict, sampleset.samples()))
-
-
-def markov_network_bqm(MN):
-    """Construct a binary quadratic model for a markov network.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        A Markov Network as returned by :func:`.markov_network`
-
-    Returns
-    -------
-    bqm : :class:`dimod.BinaryQuadraticModel`
-        A binary quadratic model.
-
-    """
-
-    bqm = dimod.BinaryQuadraticModel.empty(dimod.BINARY)
-
-    # the variable potentials
-    for v, ddict in MN.nodes(data=True, default=None):
-        potential = ddict.get('potential', None)
-
-        if potential is None:
-            continue
-
-        # for single nodes we don't need to worry about order
-
-        phi0 = potential[(0,)]
-        phi1 = potential[(1,)]
-
-        bqm.add_variable(v, phi1 - phi0)
-        bqm.offset += phi0
-
-    # the interaction potentials
-    for u, v, ddict in MN.edges(data=True, default=None):
-        potential = ddict.get('potential', None)
-
-        if potential is None:
-            continue
-
-        # in python<=3.5 the edge order might not be consistent so we use the
-        # one that was stored
-        order = ddict['order']
-        u, v = order
-
-        phi00 = potential[(0, 0)]
-        phi01 = potential[(0, 1)]
-        phi10 = potential[(1, 0)]
-        phi11 = potential[(1, 1)]
-
-        bqm.add_variable(u, phi10 - phi00)
-        bqm.add_variable(v, phi01 - phi00)
-        bqm.add_interaction(u, v, phi11 - phi10 - phi01 + phi00)
-        bqm.offset += phi00
-
-    return bqm

--- a/dwave/graphs/algorithms/markov.py
+++ b/dwave/graphs/algorithms/markov.py
@@ -54,7 +54,7 @@ __all__ = ['sample_markov_network']
 #
 
 
-def sample_markov_network(MN: nx.Graph,
+def sample_markov_network(graph: nx.Graph,
                           sampler: dimod.Sampler,
                           fixed_variables: Mapping[Variable, Bias] | None = None,
                           return_sampleset: bool = False,
@@ -63,7 +63,7 @@ def sample_markov_network(MN: nx.Graph,
     """Samples from a Markov network using the provided sampler.
 
     Args:
-        MN:
+        graph:
             A Markov network as returned by
             :func:`~dwave.graphs.generators.markov.markov_network`. Potentials
             data is stored in a node/edge attribute ``potential``.
@@ -133,7 +133,7 @@ def sample_markov_network(MN: nx.Graph,
 
     """
 
-    bqm = dimod.generators.markov_network(MN)
+    bqm = dimod.generators.markov_network(graph)
 
     if fixed_variables:
         # we can modify in-place since we just made it

--- a/dwave/graphs/algorithms/markov.py
+++ b/dwave/graphs/algorithms/markov.py
@@ -12,10 +12,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import dimod
+from collections.abc import Mapping, Sequence
 
-__all__ = ['sample_markov_network',
-           ]
+import networkx as nx
+
+import dimod
+from dimod.typing import Variable, Bias
+
+__all__ = ['sample_markov_network']
 
 
 ###############################################################################
@@ -50,35 +54,38 @@ __all__ = ['sample_markov_network',
 #
 
 
-def sample_markov_network(MN, sampler, fixed_variables=None,
-                          return_sampleset=False,
-                          **sampler_args):
-    """Samples from a markov network using the provided sampler.
+def sample_markov_network(MN: nx.Graph,
+                          sampler: dimod.Sampler,
+                          fixed_variables: Mapping[Variable, Bias] | None = None,
+                          return_sampleset: bool = False,
+                          **sampler_args,
+                          ) -> Sequence[Mapping[Variable, Bias]] | dimod.SampleSet:
+    """Samples from a Markov network using the provided sampler.
 
-    Parameters
-    ----------
-    MN : NetworkX graph
-        A Markov network as returned by :func:`~dwave.graphs.generators.markov.markov_network`
+    Args:
+        MN:
+            A Markov network as returned by
+            :func:`~dwave.graphs.generators.markov.markov_network`. Potentials
+            data is stored in a node/edge attribute ``potential``.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    fixed_variables : dict
-        A dictionary of variable assignments to be fixed in the markov network.
+        fixed_variables:
+            A dictionary of variable assignments to be fixed in the Markov
+            network.
 
-    return_sampleset : bool (optional, default=False)
-        If True, returns a :obj:`dimod.SampleSet` rather than a list of samples.
+        return_sampleset:
+            If True, returns a :class:`~dimod.SampleSet` rather than a list of
+            samples.
 
-    **sampler_args
-        Additional keyword parameters are passed to the sampler.
+        **sampler_args:
+            Additional keyword parameters are passed to the sampler.
 
-    Returns
-    -------
-    samples : list[dict]/:obj:`dimod.SampleSet`
+    Returns:
         A list of samples ordered from low-to-high energy or a sample set.
 
-    Examples
-    --------
+    Examples:
 
     >>> import dimod
     ...
@@ -120,11 +127,9 @@ def sample_markov_network(MN, sampler, fixed_variables=None,
     >>> samples[0]           # doctest: +SKIP
     {'a': 0, 'c': 0, 'b': 0}
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
     """
 

--- a/dwave/graphs/algorithms/markov.py
+++ b/dwave/graphs/algorithms/markov.py
@@ -127,12 +127,7 @@ def sample_markov_network(graph: nx.Graph,
     >>> samples[0]           # doctest: +SKIP
     {'a': 0, 'c': 0, 'b': 0}
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     """
-
     bqm = dimod.generators.markov_network(graph)
 
     if fixed_variables:

--- a/dwave/graphs/algorithms/matching.py
+++ b/dwave/graphs/algorithms/matching.py
@@ -40,6 +40,8 @@ def maximal_matching(graph: GraphLike,
     Finding maximal matchings can be done is polynomial time, so this method
     is only useful pedagogically.
 
+    Based on the formulation presented in [Luc2014]_.
+
     Args:
         graph:
             The graph on which to find a maximal matching. Either an integer
@@ -55,13 +57,8 @@ def maximal_matching(graph: GraphLike,
     Returns:
         A maximal matching of the graph.
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     .. _matching: https://en.wikipedia.org/wiki/Matching_(graph_theory)
 
-    Based on the formulation presented in [Luc2014]_.
     """
     nodes, edges = graph
 
@@ -116,15 +113,8 @@ def min_maximal_matching(graph: GraphLike,
         >>> G = dwave.graphs.chimera_graph(1, 1, 4)
         >>> matching = dwave.graphs.min_maximal_matching(G, sampler)
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     .. _matching: https://en.wikipedia.org/wiki/Matching_(graph_theory)
 
-    References:
-        Lucas, A. (2014). Ising formulations of many NP problems.
-        Frontiers in Physics, Volume 2, Article 5.
     """
     nodes, edges = graph
 

--- a/dwave/graphs/algorithms/matching.py
+++ b/dwave/graphs/algorithms/matching.py
@@ -12,62 +12,63 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from collections.abc import Hashable
+
 import dimod
+from dimod.decorators import graph_argument
+from dimod.typing import GraphLike
 
 __all__ = ['maximal_matching',
            'min_maximal_matching',
            ]
 
 
-def maximal_matching(G, sampler, **sampler_args):
+@graph_argument('graph')
+def maximal_matching(graph: GraphLike,
+                     sampler: dimod.Sampler,
+                     **sampler_args,
+                     ) -> set[Hashable]:
     """Finds an approximate maximal matching.
 
-    Defines a BQM with ground states corresponding to a maximal
-    matching and uses the sampler to sample from it.
+    Defines a BQM with ground states corresponding to a maximal matching and
+    uses the sampler to sample from it.
 
-    A matching is a subset of edges in which no node occurs more than
-    once. A maximal matching is one in which no edges from G can be
-    added without violating the matching rule.
+    A `matching`_ is a subset of edges in which no node occurs more than once.
+    A maximal matching is one in which no edges from ``graph`` can be added
+    without violating the matching rule.
 
     Finding maximal matchings can be done is polynomial time, so this method
     is only useful pedagogically.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a maximal matching.
+    Args:
+        graph:
+            The graph on which to find a maximal matching. Either an integer
+            ``n``, interpreted as a complete graph of size ``n``, a nodes/edges
+            pair, a list of edges or a NetworkX graph.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+        **sampler_args:
+            Additional keyword parameters are passed to the sampler.
 
-    Returns
-    -------
-    matching : set
+    Returns:
         A maximal matching of the graph.
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
-    References
-    ----------
-
-    `Matching on Wikipedia <https://w.wiki/r9s>`_
-
-    `QUBO on Wikipedia <https://w.wiki/r9t>`_
+    .. _matching: https://en.wikipedia.org/wiki/Matching_(graph_theory)
 
     Based on the formulation presented in [Luc2014]_.
-
     """
-    if not G.edges:
+    nodes, edges = graph
+
+    if not edges:
         return set()
 
-    bqm = dimod.generators.maximal_matching(G)
+    bqm = dimod.generators.maximal_matching(graph)
     sampleset = sampler.sample(bqm, **sampler_args)
     sample = sampleset.first.sample
 
@@ -75,65 +76,62 @@ def maximal_matching(G, sampler, **sampler_args):
     return set(tuple(edge) for edge, val in sample.items() if val > 0)
 
 
-def min_maximal_matching(G, sampler, **sampler_args):
+@graph_argument('graph')
+def min_maximal_matching(graph: GraphLike,
+                         sampler: dimod.Sampler,
+                         **sampler_args,
+                         ) -> set[Hashable]:
     """Returns an approximate minimum maximal matching.
 
-    Defines a BQM with ground states corresponding to a minimum
-    maximal matching and uses the sampler to sample from it.
+    Defines a BQM with ground states corresponding to a minimum maximal matching
+    and uses the sampler to sample from it.
 
-    A matching is a subset of edges in which no node occurs more than
-    once. A maximal matching is one in which no edges from G can be
-    added without violating the matching rule. A minimum maximal
-    matching is the smallest maximal matching for G.
+    A `matching`_ is a subset of edges in which no node occurs more than once.
+    A maximal matching is one in which no edges from ``graph`` can be added
+    without violating the matching rule. A minimum maximal matching is the
+    smallest maximal matching for ``graph``.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum maximal matching.
+    Args:
+        graph:
+            The graph on which to find a minimum maximal matching. Either an
+            integer ``n``, interpreted as a complete graph of size ``n``, a
+            nodes/edges pair, a list of edges or a NetworkX graph.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+        **sampler_args:
+            Additional keyword parameters are passed to the sampler.
 
-    Returns
-    -------
-    matching : set
+    Returns:
         A minimum maximal matching of the graph.
 
-    Example
-    -------
-    This example uses a sampler from
-    `dimod <https://github.com/dwavesystems/dimod>`_ to find a minimum maximal
-    matching for a Chimera unit cell.
+    Example:
+        This example uses a sampler from
+        `dimod <https://github.com/dwavesystems/dimod>`_ to find a minimum maximal
+        matching for a Chimera unit cell.
 
-    >>> import dimod
-    >>> sampler = dimod.ExactSolver()
-    >>> G = dwave.graphs.chimera_graph(1, 1, 4)
-    >>> matching = dwave.graphs.min_maximal_matching(G, sampler)
+        >>> import dimod
+        >>> sampler = dimod.ExactSolver()
+        >>> G = dwave.graphs.chimera_graph(1, 1, 4)
+        >>> matching = dwave.graphs.min_maximal_matching(G, sampler)
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
-    References
-    ----------
+    .. _matching: https://en.wikipedia.org/wiki/Matching_(graph_theory)
 
-    `Matching on Wikipedia <https://w.wiki/r9s>`_
-
-    `QUBO on Wikipedia <https://w.wiki/r9t>`_
-
-    Lucas, A. (2014). Ising formulations of many NP problems.
-    Frontiers in Physics, Volume 2, Article 5.
-
+    References:
+        Lucas, A. (2014). Ising formulations of many NP problems.
+        Frontiers in Physics, Volume 2, Article 5.
     """
-    if not G.edges:
+    nodes, edges = graph
+
+    if not edges:
         return set()
 
-    bqm = dimod.generators.min_maximal_matching(G)
+    bqm = dimod.generators.min_maximal_matching(graph)
     sampleset = sampler.sample(bqm, **sampler_args)
     sample = sampleset.first.sample
 

--- a/dwave/graphs/algorithms/matching.py
+++ b/dwave/graphs/algorithms/matching.py
@@ -108,7 +108,7 @@ def min_maximal_matching(graph: GraphLike,
 
     Example:
         This example uses a sampler from
-        `dimod <https://github.com/dwavesystems/dimod>`_ to find a minimum maximal
+        :ref:`index_dimod` to find a minimum maximal
         matching for a Chimera unit cell.
 
         >>> import dimod

--- a/dwave/graphs/algorithms/matching.py
+++ b/dwave/graphs/algorithms/matching.py
@@ -12,169 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import itertools
-
 import dimod
 
-__all__ = ['matching_bqm',
-           'maximal_matching_bqm',
+__all__ = ['maximal_matching',
            'min_maximal_matching',
-           'min_maximal_matching_bqm',
            ]
-
-
-def matching_bqm(G):
-    """Find a binary quadratic model for the graph's matchings.
-
-    A matching is a subset of edges in which no node occurs more than
-    once. This function returns a binary quadratic model (BQM) with ground
-    states corresponding to the possible matchings of G.
-
-    Finding valid matchings can be done in polynomial time, so finding matching
-    with BQMs is generally inefficient.
-    This BQM may be useful when combined with other constraints and objectives.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a matching.
-
-    Returns
-    -------
-    bqm : :class:`dimod.BinaryQuadraticModel`
-        A binary quadratic model with ground states corresponding to a
-        matching. The variables of the BQM are the edges of `G` as frozensets.
-        The BQM's ground state energy is 0 by construction.
-        The energy of the first excited state is 1.
-
-    """
-    bqm = dimod.BinaryQuadraticModel.empty('BINARY')
-
-    # add the edges of G as variables
-    for edge in G.edges:
-        bqm.add_variable(frozenset(edge), 0)
-
-    for node in G:
-        for edge0, edge1 in itertools.combinations(G.edges(node), 2):
-            u = frozenset(edge0)
-            v = frozenset(edge1)
-            bqm.add_interaction(u, v, 1)
-
-    return bqm
-
-
-def maximal_matching_bqm(G, lagrange=None):
-    """Find a binary quadratic model for the graph's maximal matchings.
-
-    A matching is a subset of edges in which no node occurs more than
-    once. A maximal matching is one in which no edges from G can be
-    added without violating the matching rule.
-    This function returns a binary quadratic model (BQM) with ground
-    states corresponding to the possible maximal matchings of G.
-
-    Finding maximal matchings can be done in polynomial time, so finding
-    maximal matching with BQMs is generally inefficient.
-    This BQM may be useful when combined with other constraints and objectives.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a maximal matching.
-
-    lagrange : float (optional)
-        The Lagrange multiplier for the matching constraint. Should be positive
-        and greater than `max_degree - 2`.
-        Defaults to `1.25 * (max_degree - 2)`.
-
-    Returns
-    -------
-    bqm : :class:`dimod.BinaryQuadraticModel`
-        A binary quadratic model with ground states corresponding to a maximal
-        matching. The variables of the BQM are the edges of `G` as frozensets.
-        The BQM's ground state energy is 0 by construction.
-
-    """
-    bqm = matching_bqm(G)
-
-    if lagrange is None:
-        delta = max((G.degree[v] for v in G), default=0)
-        lagrange = max(1.25 * (delta - 2), 1)
-
-    bqm.scale(lagrange)
-
-    for node0, node1 in G.edges:
-        # (1 - y_v - y_u + y_v*y_u) <- see paper
-
-        bqm.offset += 1
-
-        for edge in G.edges(node0):
-            bqm.linear[frozenset(edge)] -= 1
-
-        for edge in G.edges(node1):
-            bqm.linear[frozenset(edge)] -= 1
-
-        for edge0 in G.edges(node0):
-            u = frozenset(edge0)
-            for edge1 in G.edges(node1):
-                v = frozenset(edge1)
-                if u == v:
-                    bqm.linear[u] += 1
-                else:
-                    bqm.add_interaction(u, v, 1)
-
-    return bqm
-
-
-def min_maximal_matching_bqm(G, maximal_lagrange=2, matching_lagrange=None):
-    """Find a binary quadratic model for the graph's minimum maximal matchings.
-
-    A matching is a subset of edges in which no node occurs more than
-    once. A maximal matching is one in which no edges from G can be
-    added without violating the matching rule. A minimum maximal matching
-    is a maximal matching that contains the smallest possible number of edges.
-    This function returns a binary quadratic model (BQM) with ground
-    states corresponding to the possible maximal matchings of G.
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum maximal matching.
-
-    maximal_lagrange : float (optional, default=2)
-        The Lagrange multiplier for the maximal constraint. Should be greater
-        than 1.
-
-    matching_lagrange : float (optional)
-        The Lagrange multiplier for the matching constraint. Should be positive
-        and greater than `maximal_lagrange * max_degree - 2`.
-        Defaults to `1.25 * (maximal_lagrange * max_degree - 2)`.
-
-    Returns
-    -------
-    bqm : :class:`dimod.BinaryQuadraticModel`
-        A binary quadratic model with ground states corresponding to a
-        minimum maximal matching. The variables of the BQM are the edges
-        of `G` as frozensets.
-
-    """
-
-    if matching_lagrange is not None:
-        # we're going to scale the bqm by maximal_matching so undo that
-        # for maximal_lagrange
-        matching_lagrange /= maximal_lagrange
-    bqm = maximal_matching_bqm(G, lagrange=matching_lagrange)
-    bqm.scale(maximal_lagrange)
-
-    for v in bqm.variables:
-        bqm.linear[v] += 1
-
-    return bqm
 
 
 def maximal_matching(G, sampler, **sampler_args):
     """Finds an approximate maximal matching.
 
-    Defines a QUBO with ground states corresponding to a maximal
+    Defines a BQM with ground states corresponding to a maximal
     matching and uses the sampler to sample from it.
 
     A matching is a subset of edges in which no node occurs more than
@@ -219,7 +67,7 @@ def maximal_matching(G, sampler, **sampler_args):
     if not G.edges:
         return set()
 
-    bqm = maximal_matching_bqm(G)
+    bqm = dimod.generators.maximal_matching(G)
     sampleset = sampler.sample(bqm, **sampler_args)
     sample = sampleset.first.sample
 
@@ -230,7 +78,7 @@ def maximal_matching(G, sampler, **sampler_args):
 def min_maximal_matching(G, sampler, **sampler_args):
     """Returns an approximate minimum maximal matching.
 
-    Defines a QUBO with ground states corresponding to a minimum
+    Defines a BQM with ground states corresponding to a minimum
     maximal matching and uses the sampler to sample from it.
 
     A matching is a subset of edges in which no node occurs more than
@@ -285,7 +133,7 @@ def min_maximal_matching(G, sampler, **sampler_args):
     if not G.edges:
         return set()
 
-    bqm = min_maximal_matching_bqm(G)
+    bqm = dimod.generators.min_maximal_matching(G)
     sampleset = sampler.sample(bqm, **sampler_args)
     sample = sampleset.first.sample
 

--- a/dwave/graphs/algorithms/partition.py
+++ b/dwave/graphs/algorithms/partition.py
@@ -22,7 +22,7 @@ __all__ = ["partition",
 
 def partition(G, sampler, num_partitions=2, **sampler_args):
     """Returns an approximate k-partition of G.
-    
+
     Defines an CQM with ground states corresponding to a
     balanced k-partition of G and uses the sampler to sample from it.
     A k-partition is a collection of k subsets of the vertices
@@ -30,7 +30,7 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
     the number of edges between vertices in different subsets
     is as small as possible. If G is a weighted graph, the sum
     of weights over those edges are minimized.
-    
+
     Parameters
     ----------
     G : NetworkX graph
@@ -41,25 +41,25 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
         The number of subsets in the desired partition.
     sampler_args
         Additional keyword parameters are passed to the sampler.
-    
+
     Returns
     -------
     node_partition : dict
         The partition as a dictionary mapping each node to subsets labelled
         as integers 0, 1, 2, ... num_partitions.
-    
+
     Example
     -------
     This example uses a sampler from
     `dimod <https://github.com/dwavesystems/dimod>`_ to find a 2-partition
     for a graph of a Chimera unit cell created using the `chimera_graph()`
     function.
-    
+
     >>> import dimod
     >>> sampler = dimod.ExactCQMSolver()
     >>> G = dwave.graphs.chimera_graph(1, 1, 4)
     >>> partitions = dwave.graphs.partition(G, sampler=sampler)
-    
+
     Notes
     -----
     Samplers by their nature may not return the optimal solution. This
@@ -68,20 +68,20 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
     """
     if not len(G.nodes):
         return {}
-        
+
     cqm = dimod.generators.graph_partition(G, num_partitions)
-    
+
     # Solve the problem using the CQM solver
     response = sampler.sample_cqm(cqm, **sampler_args)
 
     # Consider only results satisfying all constraints
     possible_partitions = response.filter(lambda d: d.is_feasible)
-    
-    if not possible_partitions: 
+
+    if not possible_partitions:
         raise RuntimeError("No feasible solution could be found for this problem instance.")
 
     # Reinterpret result as partition assignment over nodes
     indicators = (key for key, value in possible_partitions.first.sample.items() if math.isclose(value, 1.))
     node_partition = {key[0]: key[1] for key in indicators}
-    
+
     return node_partition

--- a/dwave/graphs/algorithms/partition.py
+++ b/dwave/graphs/algorithms/partition.py
@@ -71,10 +71,6 @@ def partition(graph: GraphLike,
         >>> G = dwave.graphs.chimera_graph(1, 1, 4)
         >>> partitions = dwave.graphs.partition(G, sampler=sampler)
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     """
     if not len(graph.nodes):
         return {}

--- a/dwave/graphs/algorithms/partition.py
+++ b/dwave/graphs/algorithms/partition.py
@@ -13,63 +13,73 @@
 #    limitations under the License.
 
 import math
+from collections.abc import Hashable, Mapping
 
 import dimod
+from dimod.typing import GraphLike
+from dimod.decorators import graph_argument
 
 __all__ = ["partition",
            ]
 
 
-def partition(G, sampler, num_partitions=2, **sampler_args):
-    """Returns an approximate k-partition of G.
+@graph_argument('graph', as_networkx=True)
+def partition(graph: GraphLike,
+              sampler: dimod.Sampler,
+              num_partitions: int = 2,
+              **sampler_args,
+              ) -> Mapping[Hashable, int]:
+    """Return an approximate k-partition of ``graph``.
 
-    Defines an CQM with ground states corresponding to a
-    balanced k-partition of G and uses the sampler to sample from it.
-    A k-partition is a collection of k subsets of the vertices
-    of G such that each vertex is in exactly one subset, and
-    the number of edges between vertices in different subsets
-    is as small as possible. If G is a weighted graph, the sum
-    of weights over those edges are minimized.
+    Defines a CQM with ground states corresponding to a balanced k-partition of
+    ``graph`` and uses the sampler to sample from it.
+    A k-partition is a collection of k subsets of the vertices of ``graph`` such
+    that each vertex is in exactly one subset, and the number of edges between
+    vertices in different subsets is as small as possible. If ``graph`` is a
+    weighted graph, the sum of weights over those edges are minimized.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph to partition.
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
-    num_partitions : int, optional (default 2)
-        The number of subsets in the desired partition.
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+    Args:
+        graph:
+            The graph to partition. Either an integer ``n``, interpreted as a
+            complete graph of size ``n``, a nodes/edges pair, a list of edges or
+            a NetworkX graph. When NetworkX graph is provided, optional edge
+            weights can be provided in the ``weight`` attribute.
 
-    Returns
-    -------
-    node_partition : dict
+        sampler:
+            A dimod sampler.
+
+        num_partitions:
+            The number of subsets in the desired partition.
+
+        **sampler_args:
+            Additional keyword parameters are passed to the sampler.
+
+    Returns:
         The partition as a dictionary mapping each node to subsets labelled
         as integers 0, 1, 2, ... num_partitions.
 
-    Example
-    -------
-    This example uses a sampler from
-    `dimod <https://github.com/dwavesystems/dimod>`_ to find a 2-partition
-    for a graph of a Chimera unit cell created using the `chimera_graph()`
-    function.
+    Example:
+        This example uses a dimod reference sampler
+        :class:`~dimod.reference.samplers.ExactCQMSolver` to find a 2-partition
+        for a graph of a Chimera unit cell created using the
+        :meth:`~dwave.graphs.generators.chimera.chimera_graph` function.
 
-    >>> import dimod
-    >>> sampler = dimod.ExactCQMSolver()
-    >>> G = dwave.graphs.chimera_graph(1, 1, 4)
-    >>> partitions = dwave.graphs.partition(G, sampler=sampler)
+        >>> import dimod
+        >>> import dwave.graphs
+        ...
+        >>> sampler = dimod.ExactCQMSolver()
+        >>> G = dwave.graphs.chimera_graph(1, 1, 4)
+        >>> partitions = dwave.graphs.partition(G, sampler=sampler)
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
+
     """
-    if not len(G.nodes):
+    if not len(graph.nodes):
         return {}
 
-    cqm = dimod.generators.graph_partition(G, num_partitions)
+    cqm = dimod.generators.graph_partition(graph, num_partitions)
 
     # Solve the problem using the CQM solver
     response = sampler.sample_cqm(cqm, **sampler_args)
@@ -81,7 +91,8 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
         raise RuntimeError("No feasible solution could be found for this problem instance.")
 
     # Reinterpret result as partition assignment over nodes
-    indicators = (key for key, value in possible_partitions.first.sample.items() if math.isclose(value, 1.))
+    indicators = (key for key, value in possible_partitions.first.sample.items()
+                  if math.isclose(value, 1.))
     node_partition = {key[0]: key[1] for key in indicators}
 
     return node_partition

--- a/dwave/graphs/algorithms/partition.py
+++ b/dwave/graphs/algorithms/partition.py
@@ -31,9 +31,9 @@ def partition(graph: GraphLike,
               ) -> Mapping[Hashable, int]:
     """Return an approximate k-partition of ``graph``.
 
-    Defines a CQM with ground states corresponding to a balanced k-partition of
+    Defines a :term:`CQM` with ground states corresponding to a balanced k-partition of
     ``graph`` and uses the sampler to sample from it.
-    A k-partition is a collection of k subsets of the vertices of ``graph`` such
+    A k-partition is a collection of :math:`k` subsets of the vertices of ``graph`` such
     that each vertex is in exactly one subset, and the number of edges between
     vertices in different subsets is as small as possible. If ``graph`` is a
     weighted graph, the sum of weights over those edges are minimized.
@@ -56,7 +56,7 @@ def partition(graph: GraphLike,
 
     Returns:
         The partition as a dictionary mapping each node to subsets labelled
-        as integers 0, 1, 2, ... num_partitions.
+        as integers 0, 1, 2, ... ``num_partitions``.
 
     Example:
         This example uses a dimod reference sampler

--- a/dwave/graphs/algorithms/partition.py
+++ b/dwave/graphs/algorithms/partition.py
@@ -12,13 +12,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import itertools
 import math
 
 import dimod
 
 __all__ = ["partition",
-           "graph_partition_cqm",
            ]
 
 
@@ -71,7 +69,7 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
     if not len(G.nodes):
         return {}
         
-    cqm = graph_partition_cqm(G, num_partitions)
+    cqm = dimod.generators.graph_partition(G, num_partitions)
     
     # Solve the problem using the CQM solver
     response = sampler.sample_cqm(cqm, **sampler_args)
@@ -87,66 +85,3 @@ def partition(G, sampler, num_partitions=2, **sampler_args):
     node_partition = {key[0]: key[1] for key in indicators}
     
     return node_partition
-    
-    
-def graph_partition_cqm(G, num_partitions):
-    """Find a constrained quadratic model for the graph's partitions.
-
-    Defines an CQM with ground states corresponding to a
-    balanced k-partition of G and uses the sampler to sample from it.
-    A k-partition is a collection of k subsets of the vertices
-    of G such that each vertex is in exactly one subset, and
-    the number of edges between vertices in different subsets
-    is as small as possible. If G is a weighted graph, the sum
-    of weights over those edges are minimized.
-    
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph to partition.
-    num_partitions : int
-        The number of subsets in the desired partition.
-
-    Returns
-    -------
-    cqm : :class:`dimod.ConstrainedQuadraticModel`
-        A constrained quadratic model with ground states corresponding to a
-        partition problem. The nodes of `G` are discrete logical variables
-        of the CQM, where the cases are the different partitions the node
-        can be assigned to. The objective is given as the number of edges
-        connecting nodes in different partitions.
-
-    """
-    partition_size = G.number_of_nodes()/num_partitions
-    partitions = range(num_partitions)
-    cqm = dimod.ConstrainedQuadraticModel()
-
-    # Variables will be added using the discrete method in CQM
-    x = {vk: dimod.Binary(vk) for vk in itertools.product(G.nodes, partitions)}
-    
-    for v in G.nodes:
-        cqm.add_discrete(((v, k) for k in partitions), label=v)
-        
-        
-    if not math.isclose(partition_size, int(partition_size)):
-        # if number of nodes don't divide into num_partitions,
-        # accept partitions of size ceil() or floor()
-        floor, ceil = int(partition_size), int(partition_size+1)
-        for k in partitions:
-            cqm.add_constraint(dimod.quicksum((x[u, k] for u in G.nodes)) >= floor, label='equal_partition_low_%s' %k)
-            cqm.add_constraint(dimod.quicksum((x[u, k] for u in G.nodes)) <= ceil, label='equal_partition_high_%s' %k)
-    else:
-        # each partition must have partition_size elements
-        for k in partitions:
-            cqm.add_constraint(dimod.quicksum((x[u, k] for u in G.nodes)) == int(partition_size), label='equal_partition_%s' %k)
-
-    cuts = 0
-    for (u, v, d) in G.edges(data=True):
-        for k in partitions:
-            w = d.get('weight',1)
-            cuts += w * x[u,k] * x[v,k]
-            
-    if cuts:
-        cqm.set_objective(-cuts)
-
-    return cqm

--- a/dwave/graphs/algorithms/social.py
+++ b/dwave/graphs/algorithms/social.py
@@ -12,88 +12,88 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from collections.abc import Hashable, Mapping
+from typing import Literal
+
 import dimod
+import networkx as nx
 
 __all__ = ["structural_imbalance",
            ]
 
 
-def structural_imbalance(S, sampler, **sampler_args):
+def structural_imbalance(graph: nx.Graph,
+                         sampler: dimod.Sampler,
+                         **sampler_args,
+                         ) -> tuple[Mapping[tuple[Hashable, Hashable], Mapping[str, float]], # frustrated edges
+                                    Mapping[tuple[Hashable, Hashable], Literal[0, 1]]]:      # colors
     """Returns an approximate set of frustrated edges and a bicoloring.
 
-    A signed social network graph is a graph whose signed edges
-    represent friendly/hostile interactions between nodes. A
-    signed social network is considered balanced if it can be cleanly
-    divided into two factions, where all relations within a faction are
-    friendly, and all relations between factions are hostile. The measure
-    of imbalance or frustration is the minimum number of edges that
-    violate this rule.
+    A signed social network graph is a graph whose signed edges represent
+    friendly/hostile interactions between nodes. A signed social network is
+    considered balanced if it can be cleanly divided into two factions, where
+    all relations within a faction are friendly, and all relations between
+    factions are hostile. The measure of imbalance or frustration is the minimum
+    number of edges that violate this rule.
 
-    Parameters
-    ----------
-    S : NetworkX graph
-        A social graph on which each edge has a 'sign'
-        attribute with a numeric value.
+    Args:
+        graph:
+            A social graph (in a NetworkX graph) on which each edge has a 'sign'
+            attribute with a numeric value.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    sampler_args
-        Additional keyword parameters are passed to the sampler.
+        **sampler_args:
+            Additional keyword parameters passed to the sampler.
 
-    Returns
-    -------
-    frustrated_edges : dict
-        A dictionary of the edges that violate the edge sign. The imbalance
-        of the network is the length of frustrated_edges.
+    Returns:
+        A tuple with two dictionaries:
 
-    colors: dict
-        A bicoloring of the nodes into two factions.
+        - frustrated_edges:
+            A dictionary of the edges that violate the edge sign. The imbalance
+            of the network is the length of frustrated_edges.
 
-    Raises
-    ------
-    ValueError
-        If any edge does not have a 'sign' attribute.
+        - colors:
+            A bicoloring of the nodes into two factions.
 
-    Examples
-    --------
-    >>> import dimod
-    >>> sampler = dimod.ExactSolver()
-    >>> S = nx.Graph()
-    >>> S.add_edge('Alice', 'Bob', sign=1)  # Alice and Bob are friendly
-    >>> S.add_edge('Alice', 'Eve', sign=-1)  # Alice and Eve are hostile
-    >>> S.add_edge('Bob', 'Eve', sign=-1)  # Bob and Eve are hostile
-    >>> frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
-    >>> print(frustrated_edges)
-    {}
-    >>> print(colors)  # doctest: +SKIP
-    {'Alice': 0, 'Bob': 0, 'Eve': 1}
-    >>> S.add_edge('Ted', 'Bob', sign=1)  # Ted is friendly with all
-    >>> S.add_edge('Ted', 'Alice', sign=1)
-    >>> S.add_edge('Ted', 'Eve', sign=1)
-    >>> frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
-    >>> print(frustrated_edges)  # doctest: +SKIP
-    {('Ted', 'Eve'): {'sign': 1}}
-    >>> print(colors)  # doctest: +SKIP
-    {'Bob': 1, 'Ted': 1, 'Alice': 1, 'Eve': 0}
+    Raises:
+        ValueError: If any edge does not have a 'sign' attribute.
 
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Examples:
+        >>> import dimod
+        >>> sampler = dimod.ExactSolver()
+        >>> S = nx.Graph()
+        >>> S.add_edge('Alice', 'Bob', sign=1)   # Alice and Bob are friendly
+        >>> S.add_edge('Alice', 'Eve', sign=-1)  # Alice and Eve are hostile
+        >>> S.add_edge('Bob', 'Eve', sign=-1)    # Bob and Eve are hostile
+        >>> frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
+        >>> print(frustrated_edges)
+        {}
+        >>> print(colors)  # doctest: +SKIP
+        {'Alice': 0, 'Bob': 0, 'Eve': 1}
+        >>> S.add_edge('Ted', 'Bob', sign=1)     # Ted is friendly with all
+        >>> S.add_edge('Ted', 'Alice', sign=1)
+        >>> S.add_edge('Ted', 'Eve', sign=1)
+        >>> frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
+        >>> print(frustrated_edges)  # doctest: +SKIP
+        {('Ted', 'Eve'): {'sign': 1}}
+        >>> print(colors)  # doctest: +SKIP
+        {'Bob': 1, 'Ted': 1, 'Alice': 1, 'Eve': 0}
 
-    References
-    ----------
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
-    `Ising model on Wikipedia <https://en.wikipedia.org/wiki/Ising_model>`_
+    References:
+        `Ising model on Wikipedia <https://en.wikipedia.org/wiki/Ising_model>`_
 
-    Facchetti, G., Iacono G., and Altafini C. (2011). 
-    Computing global structural balance in large-scale signed social networks.
-    PNAS, 108, no. 52, 20953-20958
+        Facchetti, G., Iacono G., and Altafini C. (2011).
+        Computing global structural balance in large-scale signed social networks.
+        PNAS, 108, no. 52, 20953-20958
 
     """
-    bqm = dimod.generators.social.structural_imbalance(S)
+    bqm = dimod.generators.social.structural_imbalance(graph)
 
     # use the sampler to find low energy states
     response = sampler.sample(bqm, **sampler_args)
@@ -106,7 +106,7 @@ def structural_imbalance(S, sampler, **sampler_args):
 
     # frustrated edges are the ones that are violated
     frustrated_edges = {}
-    for u, v, data in S.edges(data=True):
+    for u, v, data in graph.edges(data=True):
         sign = data['sign']
 
         if sign > 0 and colors[u] != colors[v]:

--- a/dwave/graphs/algorithms/social.py
+++ b/dwave/graphs/algorithms/social.py
@@ -12,7 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-__all__ = ["structural_imbalance"]
+import dimod
+
+__all__ = ["structural_imbalance",
+           ]
 
 
 def structural_imbalance(S, sampler, **sampler_args):
@@ -90,10 +93,10 @@ def structural_imbalance(S, sampler, **sampler_args):
     PNAS, 108, no. 52, 20953-20958
 
     """
-    h, J = structural_imbalance_ising(S)
+    bqm = dimod.generators.social.structural_imbalance(S)
 
     # use the sampler to find low energy states
-    response = sampler.sample_ising(h, J, **sampler_args)
+    response = sampler.sample(bqm, **sampler_args)
 
     # we want the lowest energy sample
     sample = next(iter(response))
@@ -113,63 +116,3 @@ def structural_imbalance(S, sampler, **sampler_args):
         # else: not frustrated or sign == 0, no relation to violate
 
     return frustrated_edges, colors
-
-
-def structural_imbalance_ising(S):
-    """Construct the Ising problem to calculate the structural imbalance of a signed social network.
-
-    A signed social network graph is a graph whose signed edges
-    represent friendly/hostile interactions between nodes. A
-    signed social network is considered balanced if it can be cleanly
-    divided into two factions, where all relations within a faction are
-    friendly, and all relations between factions are hostile. The measure
-    of imbalance or frustration is the minimum number of edges that
-    violate this rule.
-
-    Parameters
-    ----------
-    S : NetworkX graph
-        A social graph on which each edge has a 'sign' attribute with a numeric value.
-
-    Returns
-    -------
-    h : dict
-        The linear biases of the Ising problem. Each variable in the Ising problem represent
-        a node in the signed social network. The solution that minimized the Ising problem
-        will assign each variable a value, either -1 or 1. This bi-coloring defines the factions.
-
-    J : dict
-        The quadratic biases of the Ising problem.
-
-    Raises
-    ------
-    ValueError
-        If any edge does not have a 'sign' attribute.
-
-    Examples
-    --------
-    >>> import dimod
-    >>> from dwave.graphs.algorithms.social import structural_imbalance_ising
-    ...
-    >>> S = nx.Graph()
-    >>> S.add_edge('Alice', 'Bob', sign=1)  # Alice and Bob are friendly
-    >>> S.add_edge('Alice', 'Eve', sign=-1)  # Alice and Eve are hostile
-    >>> S.add_edge('Bob', 'Eve', sign=-1)  # Bob and Eve are hostile
-    ...
-    >>> h, J = structural_imbalance_ising(S)
-    >>> h  # doctest: +SKIP
-    {'Alice': 0.0, 'Bob': 0.0, 'Eve': 0.0}
-    >>> J  # doctest: +SKIP
-    {('Alice', 'Bob'): -1.0, ('Alice', 'Eve'): 1.0, ('Bob', 'Eve'): 1.0}
-
-    """
-    h = {v: 0.0 for v in S}
-    J = {}
-    for u, v, data in S.edges(data=True):
-        try:
-            J[(u, v)] = -1. * data['sign']
-        except KeyError:
-            raise ValueError(("graph should be a signed social graph,"
-                              "each edge should have a 'sign' attr"))
-
-    return h, J

--- a/dwave/graphs/algorithms/social.py
+++ b/dwave/graphs/algorithms/social.py
@@ -81,10 +81,6 @@ def structural_imbalance(graph: nx.Graph,
         >>> print(colors)  # doctest: +SKIP
         {'Bob': 1, 'Ted': 1, 'Alice': 1, 'Eve': 0}
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     References:
         `Ising model on Wikipedia <https://en.wikipedia.org/wiki/Ising_model>`_
 

--- a/dwave/graphs/algorithms/tsp.py
+++ b/dwave/graphs/algorithms/tsp.py
@@ -12,7 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from collections.abc import Hashable, Iterable, Sequence
+
 import dimod
+import networkx as nx
 
 __all__ = ["traveling_salesperson",
            "traveling_salesman",
@@ -20,71 +23,72 @@ __all__ = ["traveling_salesperson",
            ]
 
 
-def traveling_salesperson(G, sampler, lagrange=None, weight='weight',
-                          start=None, **sampler_args):
+def traveling_salesperson(graph: nx.Graph,
+                          sampler: dimod.Sampler,
+                          lagrange: float | None = None,
+                          weight: str = 'weight',
+                          start: Hashable | None = None,
+                          **sampler_args,
+                          ) -> Sequence[Hashable]:
     """Returns an approximate minimum traveling salesperson route.
 
-    Defines a QUBO with ground states corresponding to the
-    minimum routes and uses the sampler to sample
-    from it.
+    Defines a binary quadratic model (:term:`BQM`) with ground states corresponding to
+    the minimum routes and uses the sampler to sample from it.
 
     A route is a cycle in the graph that reaches each node exactly once.
     A minimum route is a route with the smallest total edge weight.
 
-    Parameters
-    ----------
-    G : NetworkX graph
-        The graph on which to find a minimum traveling salesperson route.
-        This should be a complete graph with non-zero weights on every edge.
+    Args:
+        graph:
+            The graph on which to find a minimum traveling salesperson route.
+            This should be a complete graph with non-zero weights on every edge.
 
-    sampler : :class:`dimod.Sampler`
-        A dimod sampler.
+        sampler:
+            A dimod sampler.
 
-    lagrange : number, optional (default None)
-        Lagrange parameter to weight constraints (visit every city once)
-        versus objective (shortest distance route).
+        lagrange:
+            Lagrange parameter to weight constraints (visit every city once)
+            versus objective (shortest distance route). If not specified, it's
+            estimated based on graph size.
+            See :meth:`~dimod.generators.tsp.traveling_salesperson` BQM generator.
 
-    weight : optional (default 'weight')
-        The name of the edge attribute containing the weight.
+        weight:
+            The name of the edge attribute containing the weight.
 
-    start : node, optional
-        If provided, the route will begin at `start`.
+        start:
+            If provided, the route will begin at ``start``.
 
-    sampler_args :
-        Additional keyword parameters are passed to the sampler.
+        **sampler_args:
+            Additional keyword parameters passed to the sampler.
 
-    Returns
-    -------
-    route : list
-       List of nodes in order to be visited on a route
+    Returns:
+       List of nodes in order to be visited on a route.
 
-    Examples
-    --------
+    Example:
+        >>> import dimod
+        >>> import dwave.graphs
+        >>> import networkx
+        ...
+        >>> G = networkx.Graph()
+        >>> G.add_weighted_edges_from({(0, 1, .1), (0, 2, .5), (0, 3, .1),
+        ...                            (1, 2, .1), (1, 3, .5), (2, 3, .1)})
+        >>> dwave.graphs.traveling_salesperson(G, dimod.ExactSolver(), start=0) # doctest: +SKIP
+        [0, 1, 2, 3]
 
-    >>> import dimod
-    ...
-    >>> G = nx.Graph()
-    >>> G.add_weighted_edges_from({(0, 1, .1), (0, 2, .5), (0, 3, .1), (1, 2, .1),
-    ...                            (1, 3, .5), (2, 3, .1)})
-    >>> dwave.graphs.traveling_salesperson(G, dimod.ExactSolver(), start=0) # doctest: +SKIP
-    [0, 1, 2, 3]
-
-    Notes
-    -----
-    Samplers by their nature may not return the optimal solution. This
-    function does not attempt to confirm the quality of the returned
-    sample.
+    Note:
+        Samplers by their nature may not return the optimal solution. This
+        function does not attempt to confirm the quality of the returned sample.
 
     """
     # Get a QUBO representation of the problem
-    bqm = dimod.generators.traveling_salesperson(G, lagrange, weight)
+    bqm = dimod.generators.traveling_salesperson(graph, lagrange=lagrange, weight=weight)
 
     # use the sampler to find low energy states
     response = sampler.sample(bqm, **sampler_args)
 
     sample = response.first.sample
 
-    route = [None] * len(G)
+    route = [None] * len(graph)
     for (city, time), val in sample.items():
         if val:
             route[time] = city
@@ -100,26 +104,20 @@ def traveling_salesperson(G, sampler, lagrange=None, weight='weight',
 traveling_salesman = traveling_salesperson
 
 
-def is_hamiltonian_path(G, route):
+def is_hamiltonian_path(graph: nx.Graph, route: Iterable[Hashable]) -> bool:
     """Determines whether the given list forms a valid TSP route.
 
-    A travelling salesperson route must visit each city exactly once.
+    A traveling salesperson route must visit each city exactly once.
 
-    Parameters
-    ----------
-    G : NetworkX graph
+    Args:
+        graph:
+            The graph on which to check the route.
 
-        The graph on which to check the route.
+        route:
+            List of nodes in the order that they are visited.
 
-    route : list
-
-        List of nodes in the order that they are visited.
-
-    Returns
-    -------
-    is_valid : bool
-        True if route forms a valid travelling salesperson route.
-
+    Returns:
+        True if route forms a valid traveling salesperson route.
     """
 
-    return set(route) == set(G)
+    return set(route) == set(graph)

--- a/dwave/graphs/algorithms/tsp.py
+++ b/dwave/graphs/algorithms/tsp.py
@@ -75,10 +75,6 @@ def traveling_salesperson(graph: nx.Graph,
         >>> dwave.graphs.traveling_salesperson(G, dimod.ExactSolver(), start=0) # doctest: +SKIP
         [0, 1, 2, 3]
 
-    Note:
-        Samplers by their nature may not return the optimal solution. This
-        function does not attempt to confirm the quality of the returned sample.
-
     """
     # Get a QUBO representation of the problem
     bqm = dimod.generators.traveling_salesperson(graph, lagrange=lagrange, weight=weight)

--- a/dwave/graphs/algorithms/tsp.py
+++ b/dwave/graphs/algorithms/tsp.py
@@ -12,13 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import itertools
-from collections import defaultdict
+import dimod
 
 __all__ = ["traveling_salesperson",
-           "traveling_salesperson_qubo",
            "traveling_salesman",
-           "traveling_salesman_qubo",
            "is_hamiltonian_path",
            ]
 
@@ -80,14 +77,14 @@ def traveling_salesperson(G, sampler, lagrange=None, weight='weight',
 
     """
     # Get a QUBO representation of the problem
-    Q = traveling_salesperson_qubo(G, lagrange, weight)
+    bqm = dimod.generators.traveling_salesperson(G, lagrange, weight)
 
     # use the sampler to find low energy states
-    response = sampler.sample_qubo(Q, **sampler_args)
+    response = sampler.sample(bqm, **sampler_args)
 
     sample = response.first.sample
 
-    route = [None]*len(G)
+    route = [None] * len(G)
     for (city, time), val in sample.items():
         if val:
             route[time] = city
@@ -101,108 +98,6 @@ def traveling_salesperson(G, sampler, lagrange=None, weight='weight',
 
 
 traveling_salesman = traveling_salesperson
-
-
-def traveling_salesperson_qubo(G, lagrange=None, weight='weight', missing_edge_weight=None):
-    """Return the QUBO with ground states corresponding to a minimum TSP route.
-
-    If :math:`|G|` is the number of nodes in the graph, the resulting qubo will have:
-
-    * :math:`|G|^2` variables/nodes
-    * :math:`2 |G|^2 (|G| - 1)` interactions/edges
-
-    Parameters
-    ----------
-    G : NetworkX graph
-        A complete graph in which each edge has a attribute giving its weight.
-
-    lagrange : number, optional (default None)
-        Lagrange parameter to weight constraints (no edges within set)
-        versus objective (largest set possible).
-
-    weight : optional (default 'weight')
-        The name of the edge attribute containing the weight.
-    
-    missing_edge_weight : number, optional (default None)
-        For bi-directional graphs, the weight given to missing edges.
-        If None is given (the default), missing edges will be set to
-        the sum of all weights.
-
-    Returns
-    -------
-    QUBO : dict
-       The QUBO with ground states corresponding to a minimum travelling
-       salesperson route. The QUBO variables are labelled `(c, t)` where `c`
-       is a node in `G` and `t` is the time index. For instance, if `('a', 0)`
-       is 1 in the ground state, that means the node 'a' is visted first.
-
-    """
-    N = G.number_of_nodes()
-
-    if lagrange is None:
-        # If no lagrange parameter provided, set to 'average' tour length.
-        # Usually a good estimate for a lagrange parameter is between 75-150%
-        # of the objective function value, so we come up with an estimate for 
-        # tour length and use that.
-        if G.number_of_edges()>0:
-            lagrange = G.size(weight=weight)*G.number_of_nodes()/G.number_of_edges()
-        else:
-            lagrange = 2
-    
-    # calculate default missing_edge_weight if required
-    if missing_edge_weight is None:
-        # networkx method to calculate sum of all weights
-        missing_edge_weight = G.size(weight=weight)
-
-    # some input checking
-    if N in (1, 2):
-        msg = "graph must have at least 3 nodes or be empty"
-        raise ValueError(msg)
-
-    # Creating the QUBO
-    Q = defaultdict(float)
-
-    # Constraint that each row has exactly one 1
-    for node in G:
-        for pos_1 in range(N):
-            Q[((node, pos_1), (node, pos_1))] -= lagrange
-            for pos_2 in range(pos_1+1, N):
-                Q[((node, pos_1), (node, pos_2))] += 2.0*lagrange
-
-    # Constraint that each col has exactly one 1
-    for pos in range(N):
-        for node_1 in G:
-            Q[((node_1, pos), (node_1, pos))] -= lagrange
-            for node_2 in set(G)-{node_1}:
-                # QUBO coefficient is 2*lagrange, but we are placing this value 
-                # above *and* below the diagonal, so we put half in each position.
-                Q[((node_1, pos), (node_2, pos))] += lagrange
-
-    # Objective that minimizes distance
-    for u, v in itertools.combinations(G.nodes, 2):
-        for pos in range(N):
-            nextpos = (pos + 1) % N
-
-            # going from u -> v
-            try:
-                value = G[u][v][weight]
-            except KeyError:
-                value = missing_edge_weight
-
-            Q[((u, pos), (v, nextpos))] += value
-
-            # going from v -> u
-            try:
-                value = G[v][u][weight]
-            except KeyError:
-                value = missing_edge_weight
-
-            Q[((v, pos), (u, nextpos))] += value
-
-    return Q
-
-
-traveling_salesman_qubo = traveling_salesperson_qubo
 
 
 def is_hamiltonian_path(G, route):
@@ -227,4 +122,4 @@ def is_hamiltonian_path(G, route):
 
     """
 
-    return (set(route) == set(G))
+    return set(route) == set(G)

--- a/dwave/graphs/generators/markov.py
+++ b/dwave/graphs/generators/markov.py
@@ -13,12 +13,12 @@
 #    limitations under the License.
 
 import itertools
-import collections.abc as abc
+from collections.abc import Hashable, Mapping
 
 import networkx as nx
 
 
-__all__ = 'markov_network',
+__all__ = ['markov_network']
 
 
 ###############################################################################
@@ -53,26 +53,23 @@ __all__ = 'markov_network',
 #
 
 
-def markov_network(potentials):
-    """Creates a Markov Network from potentials.
+def markov_network(potentials: Mapping[Hashable, Mapping[Hashable, float]],
+                   ) -> nx.Graph:
+    """Creates a Markov network from potentials.
 
-    A Markov Network is also knows as a `Markov Random Field`_
+    A Markov network is also knows as a `Markov Random Field`_
 
-    Parameters
-    ----------
-    potentials : dict[tuple, dict]
-        A dict where the keys are either nodes or edges and the values are a
-        dictionary of potentials. The potential dict should map each possible
-        assignment of the nodes/edges to their energy.
+    Args:
+        potentials:
+            A mapping where the keys are either nodes or edges and the values
+            are a mapping of potentials. The potential dict should map each
+            possible assignment of the nodes/edges to their energy.
 
-    Returns
-    -------
-    MN : :obj:`networkx.Graph`
-        A markov network as a graph where each node/edge stores its potential
-        dict as above.
+    Returns:
+        A markov network as a NetworkX graph where each node/edge stores its
+        potential dict as above.
 
-    Examples
-    --------
+    Example:
     >>> potentials = {('a', 'b'): {(0, 0): -1,
     ...                            (0, 1): .5,
     ...                            (1, 0): .5,
@@ -97,8 +94,8 @@ def markov_network(potentials):
 
         # because this data potentially wont be used for a while, let's do some
         # input checking now and save some debugging issues later
-        if not isinstance(phis, abc.Mapping):
-            raise TypeError("phis should be a dict")
+        if not isinstance(phis, Mapping):
+            raise TypeError("node/edge potentials should be a dict")
         elif not all(config in phis for config in itertools.product((0, 1), repeat=num_vars)):
             raise ValueError("not all potentials provided for {!r}".format(clique))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "dimod>=0.12.16,<0.13",     # oldest that supports numpy 2
+    "dimod>=0.12.22,<0.13",     # includes migrated BQM generators
     "networkx>=3.2,<4",         # oldest that supports numpy 2
     "numpy>=2,<3",
 ]
@@ -46,7 +46,7 @@ changelog = [
 dev = [
     "numpy==2.2.6; python_version < '3.11'",    # latest that supports 3.10
     "numpy==2.4.4; python_version >= '3.11'",   # latest as of April 2026
-    "dimod==0.12.21",       # latest that supports 3.10 through 3.14
+    "dimod==0.12.22",       # latest that includes the migrated BQM generators
     "networkx==3.4.2",      # latest that supports 3.10 (and numpy 2)
     {include-group = "changelog"},
 ]

--- a/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
+++ b/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
@@ -1,0 +1,29 @@
+---
+prelude: >
+    Binary quadratic model (i.e. Ising model and QUBO) generators have been
+    moved from ``dwave.graphs.algorithms`` to ``dimod.generators``.
+upgrade:
+  - |
+    All BQM/Ising/QUBO generators from ``dwave.graphs.algorithms`` have been
+    migrated to ``dimod.generators`` (released in ``dimod==0.12.22``):
+
+    - ``min_vertex_color_qubo`` and ``vertex_color_qubo`` removed from
+      ``dwave.graphs.algorithms.coloring`` in favor of ``min_vertex_coloring``
+      and ``vertex_coloring`` from ``dimod.generators.coloring``,
+
+    - ``dwave.graphs.algorithms.markov.markov_network_bqm`` removed in favor of
+      ``dimod.generators.markov.markov_network``,
+
+    - ``matching_bqm``, ``maximal_matching_bqm`` and ``min_maximal_matching_bqm``
+      removed from ``dwave.graphs.algorithms.matching`` in favor of
+      ``maximal_matching`` and ``min_maximal_matching`` from
+      ``dimod.generators.matching``,
+
+    - ``dwave.graphs.algorithms.partition.graph_partition_cqm`` removed in
+      favor of ``dimod.generators.partition.graph_partition``,
+
+    - ``dwave.graphs.algorithms.social.structural_imbalance_ising`` removed in
+      favor of ``dimod.generators.social.structural_imbalance`` and
+
+    - ``dwave.graphs.algorithms.tsp.traveling_salesperson_qubo`` removed in
+      favor of ``dimod.generators.tsp.traveling_salesperson``.

--- a/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
+++ b/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
@@ -27,3 +27,5 @@ upgrade:
 
     - ``dwave.graphs.algorithms.tsp.traveling_salesperson_qubo`` removed in
       favor of ``dimod.generators.tsp.traveling_salesperson``.
+  - |
+    Drop support for ``dimod<0.12.22``.

--- a/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
+++ b/releasenotes/notes/remove-bqm-generators-migrated-to-dimod-f4eb07c79bb7f73d.yaml
@@ -29,3 +29,6 @@ upgrade:
       favor of ``dimod.generators.tsp.traveling_salesperson``.
   - |
     Drop support for ``dimod<0.12.22``.
+  - |
+    Drop ``vertex_color`` and ``min_vertex_color`` aliases in favor of
+    ``vertex_coloring`` and ``min_vertex_coloring`` for consistency.

--- a/tests/test_coloring.py
+++ b/tests/test_coloring.py
@@ -52,7 +52,7 @@ class TestVertexColor(unittest.TestCase):
     def test_4cycle(self):
         G = nx.cycle_graph('abcd')
 
-        coloring = dwave.graphs.vertex_color(G, 2, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_coloring(G, 2, dimod.ExactSolver())
 
         self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
@@ -61,17 +61,17 @@ class TestVertexColor(unittest.TestCase):
         G.add_edge(0, 2)
 
         # need 3 colors in this case
-        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_coloring(G, 3, dimod.ExactSolver())
 
         self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_5cycle(self):
         G = nx.cycle_graph(5)
-        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_coloring(G, 3, dimod.ExactSolver())
         self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_disconnected_cycle_graph(self):
         G = nx.complete_graph(3)  # odd 3-cycle
         G.add_node(4)  # floating node
-        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_coloring(G, 3, dimod.ExactSolver())
         self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))

--- a/tests/test_coloring.py
+++ b/tests/test_coloring.py
@@ -14,144 +14,64 @@
 
 import unittest
 
+import dimod
 import networkx as nx
 
-import dimod
-
-import dwave.graphs as dnx
+import dwave.graphs
 
 
 class TestMinVertexColor(unittest.TestCase):
-
     def test_5path(self):
         G = nx.path_graph(5)
-        coloring = dnx.min_vertex_coloring(G, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        coloring = dwave.graphs.min_vertex_coloring(G, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
         self.assertEqual(len(set(coloring.values())), 2)  # bipartite
 
     def test_odd_cycle_graph(self):
         """Graph that is an odd circle"""
         G = nx.cycle_graph(5)
-        coloring = dnx.min_vertex_coloring(G, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        coloring = dwave.graphs.min_vertex_coloring(G, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_disconnected_graph(self):
         """One edge and one disconnected node"""
         G = nx.path_graph(2)
         G.add_node(3)
 
-        coloring = dnx.min_vertex_coloring(G, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        coloring = dwave.graphs.min_vertex_coloring(G, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_disconnected_cycle_graph(self):
         G = nx.complete_graph(3)  # odd 3-cycle
         G.add_node(4)  # floating node
-        coloring = dnx.min_vertex_coloring(G, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
-
-
-class TestMinVertexColorQubo(unittest.TestCase):
-    def test_chromatic_number(self):
-        G = nx.cycle_graph('abcd')
-
-        # when the chromatic number is fixed this is exactly vertex_color
-        self.assertEqual(dnx.min_vertex_color_qubo(G, chromatic_lb=2,
-                                                   chromatic_ub=2),
-                         dnx.vertex_color_qubo(G, 2))
+        coloring = dwave.graphs.min_vertex_coloring(G, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
 
 class TestVertexColor(unittest.TestCase):
     def test_4cycle(self):
         G = nx.cycle_graph('abcd')
 
-        coloring = dnx.vertex_color(G, 2, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_color(G, 2, dimod.ExactSolver())
 
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_4cycle_with_chord(self):
         G = nx.cycle_graph(4)
         G.add_edge(0, 2)
 
         # need 3 colors in this case
-        coloring = dnx.vertex_color(G, 3, dimod.ExactSolver())
+        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
 
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_5cycle(self):
         G = nx.cycle_graph(5)
-        coloring = dnx.vertex_color(G, 3, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
+        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))
 
     def test_disconnected_cycle_graph(self):
         G = nx.complete_graph(3)  # odd 3-cycle
         G.add_node(4)  # floating node
-        coloring = dnx.vertex_color(G, 3, dimod.ExactSolver())
-        self.assertTrue(dnx.is_vertex_coloring(G, coloring))
-
-
-class TestVertexColorQUBO(unittest.TestCase):
-    def test_single_node(self):
-        G = nx.Graph()
-        G.add_node('a')
-
-        # a single color
-        Q = dnx.vertex_color_qubo(G, ['red'])
-
-        self.assertEqual(Q, {(('a', 'red'), ('a', 'red')): -1})
-
-    def test_4cycle(self):
-        G = nx.cycle_graph('abcd')
-
-        Q = dnx.vertex_color_qubo(G, 2)
-
-        sampleset = dimod.ExactSolver().sample_qubo(Q)
-
-        # check that the ground state is a valid coloring
-        ground_energy = sampleset.first.energy
-
-        colorings = []
-        for sample, en in sampleset.data(['sample', 'energy']):
-            if en > ground_energy:
-                break
-
-            coloring = {}
-            for (v, c), val in sample.items():
-                if val:
-                    coloring[v] = c
-
-            self.assertTrue(dnx.is_vertex_coloring(G, coloring))
-
-            colorings.append(coloring)
-
-        # there are two valid colorings
-        self.assertEqual(len(colorings), 2)
-
-        self.assertEqual(ground_energy, -len(G))
-
-    def test_num_variables(self):
-        G = nx.Graph()
-        G.add_nodes_from(range(15))
-
-        Q = dnx.vertex_color_qubo(G, 7)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-        self.assertEqual(len(bqm.quadratic), len(G)*7*(7-1)/2)
-
-        # add one edge
-        G.add_edge(0, 1)
-        Q = dnx.vertex_color_qubo(G, 7)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-        self.assertEqual(len(bqm.quadratic), len(G)*7*(7-1)/2 + 7)
-
-    def test_docstring_stats(self):
-        # get a complex-ish graph
-        G = nx.karate_club_graph()
-
-        colors = range(10)
-
-        Q = dnx.vertex_color_qubo(G, colors)
-
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-        self.assertEqual(len(bqm), len(G)*len(colors))
-        self.assertEqual(len(bqm.quadratic), len(G)*len(colors)*(len(colors)-1)/2
-                         + len(G.edges)*len(colors))
+        coloring = dwave.graphs.vertex_color(G, 3, dimod.ExactSolver())
+        self.assertTrue(dwave.graphs.is_vertex_coloring(G, coloring))

--- a/tests/test_independent_set.py
+++ b/tests/test_independent_set.py
@@ -47,59 +47,6 @@ class TestIsIndependentSet(unittest.TestCase):
         self.assertFalse(dnx.is_independent_set(G, [0, 1]))
 
 
-class TestWeightedMaximumIndependentSet(unittest.TestCase):
-    def test_empty(self):
-        G = nx.Graph()
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G)
-
-        self.assertEqual(Q, {})
-
-    def test_K1_no_weights(self):
-        G = nx.complete_graph(1)
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G)
-
-        self.assertEqual(Q, {(0, 0): -1})
-
-    def test_K1_weighted(self):
-        G = nx.Graph()
-        G.add_node(0, weight=.5)
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G)
-
-        self.assertEqual(Q, {(0, 0): -1.})  # should be scaled to 1
-
-    def test_K2_weighted(self):
-        G = nx.Graph()
-        G.add_node(0, weight=.5)
-        G.add_node(1, weight=1)
-        G.add_edge(0, 1)
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G, weight='weight')
-
-        self.assertEqual(Q, {(0, 0): -.5, (1, 1): -1, (0, 1): 2.0})
-
-    def test_K2_partially_weighted(self):
-        G = nx.Graph()
-        G.add_node(0, weight=.5)
-        G.add_node(1)
-        G.add_edge(0, 1)
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G, weight='weight')
-
-        self.assertEqual(Q, {(0, 0): -.5, (1, 1): -1, (0, 1): 2.0})
-
-    def test_path3_weighted(self):
-        G = nx.path_graph(3)
-        G.nodes[1]['weight'] = 2.1
-
-        Q = dnx.maximum_weighted_independent_set_qubo(G, weight='weight')
-
-        self.assertLess(dimod.qubo_energy({0: 0, 1: 1, 2: 0}, Q),
-                        dimod.qubo_energy({0: 1, 1: 0, 2: 1}, Q))
-
-
 class TestIndepSet(unittest.TestCase):
 
     def test_maximum_independent_set_basic(self):

--- a/tests/test_markov.py
+++ b/tests/test_markov.py
@@ -13,53 +13,10 @@
 #    limitations under the License.
 
 import unittest
+
 import dimod
 
-import dwave.graphs as dnx
-
-
-class Test_sample_markov_network_bqm(unittest.TestCase):
-    def test_one_node(self):
-        potentials = {'a': {(0,): 1.2, (1,): .4}}
-
-        bqm = dnx.markov_network_bqm(dnx.markov_network(potentials))
-
-        for edge, potential in potentials.items():
-            for config, energy in potential.items():
-                sample = dict(zip(edge, config))
-                self.assertAlmostEqual(bqm.energy(sample), energy)
-
-    def test_one_edge(self):
-        potentials = {'ab': {(0, 0): 1.2, (1, 0): .4,
-                             (0, 1): 1.3, (1, 1): -4}}
-
-        bqm = dnx.markov_network_bqm(dnx.markov_network(potentials))
-
-        for edge, potential in potentials.items():
-            for config, energy in potential.items():
-                sample = dict(zip(edge, config))
-                self.assertAlmostEqual(bqm.energy(sample), energy)
-
-    def test_typical(self):
-        potentials = {'a': {(0,): 1.5, (1,): -.5},
-                      'ab': {(0, 0): 1.2, (1, 0): .4,
-                             (0, 1): 1.3, (1, 1): -4},
-                      'bc': {(0, 0): 1.7, (1, 0): .4,
-                             (0, 1): -1, (1, 1): -4},
-                      'd': {(0,): -.5, (1,): 1.6}}
-
-        bqm = dnx.markov_network_bqm(dnx.markov_network(potentials))
-
-        samples = dimod.ExactSolver().sample(bqm)
-
-        for sample, energy in samples.data(['sample', 'energy']):
-
-            en = 0
-            for interaction, potential in potentials.items():
-                config = tuple(sample[v] for v in interaction)
-                en += potential[config]
-
-            self.assertAlmostEqual(en, energy)
+import dwave.graphs
 
 
 class Test_sample_markov_network(unittest.TestCase):
@@ -71,11 +28,11 @@ class Test_sample_markov_network(unittest.TestCase):
                              (0, 1): -1, (1, 1): -4},
                       'd': {(0,): -.5, (1,): 1.6}}
 
-        MN = dnx.markov_network(potentials)
+        MN = dwave.graphs.generators.markov_network(potentials)
 
-        samples = dnx.sample_markov_network(MN, dimod.ExactSolver(),
-                                            fixed_variables={'c': 0},
-                                            return_sampleset=True)
+        samples = dwave.graphs.algorithms.sample_markov_network(
+            MN, dimod.ExactSolver(), fixed_variables={'c': 0},
+            return_sampleset=True)
 
         for sample, energy in samples.data(['sample', 'energy']):
             self.assertEqual(sample['c'], 0)
@@ -95,12 +52,12 @@ class Test_sample_markov_network(unittest.TestCase):
                              (0, 1): -1, (1, 1): -4},
                       'd': {(0,): -.5, (1,): 1.6}}
 
-        MN = dnx.markov_network(potentials)
+        MN = dwave.graphs.generators.markov_network(potentials)
 
-        bqm = dnx.markov_network_bqm(MN)
+        bqm = dimod.generators.markov_network(MN)
 
-        samples = dnx.sample_markov_network(MN, dimod.ExactSolver(),
-                                            fixed_variables={'c': 0})
+        samples = dwave.graphs.algorithms.sample_markov_network(
+            MN, dimod.ExactSolver(), fixed_variables={'c': 0})
 
         for sample in samples:
             self.assertEqual(sample['c'], 0)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -18,7 +18,7 @@ import dimod
 import networkx as nx
 import parameterized
 
-import dwave.graphs as dnx
+import dwave.graphs
 
 
 @parameterized.parameterized_class(
@@ -35,67 +35,12 @@ import dwave.graphs as dnx
      ]
     )
 class TestMatching(unittest.TestCase):
-    def test_matching_bqm(self):
-        bqm = dnx.matching_bqm(self.graph)
-
-        # the ground states should be exactly the matchings of G
-        sampleset = dimod.ExactSolver().sample(bqm)
-
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            edges = [v for v, val in sample.items() if val > 0]
-            self.assertEqual(nx.is_matching(self.graph, edges), energy == 0)
-            self.assertTrue(energy == 0 or energy >= 1)
-
     def test_maximal_matching(self):
-        matching = dnx.algorithms.matching.maximal_matching(
+        matching = dwave.graphs.algorithms.maximal_matching(
             self.graph, dimod.ExactSolver())
         self.assertTrue(nx.is_maximal_matching(self.graph, matching))
 
-    def test_maximal_matching_bqm(self):
-        bqm = dnx.maximal_matching_bqm(self.graph)
-
-        # the ground states should be exactly the maximal matchings of G
-        sampleset = dimod.ExactSolver().sample(bqm)
-
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            edges = set(v for v, val in sample.items() if val > 0)
-            self.assertEqual(nx.is_maximal_matching(self.graph, edges),
-                             energy == 0)
-            self.assertGreaterEqual(energy, 0)
-
     def test_min_maximal_matching(self):
-        matching = dnx.min_maximal_matching(self.graph, dimod.ExactSolver())
+        matching = dwave.graphs.algorithms.min_maximal_matching(
+            self.graph, dimod.ExactSolver())
         self.assertTrue(nx.is_maximal_matching(self.graph, matching))
-
-    def test_min_maximal_matching_bqm(self):
-        bqm = dnx.min_maximal_matching_bqm(self.graph)
-
-        if len(self.graph) == 0:
-            self.assertEqual(len(bqm.linear), 0)
-            return
-
-        # the ground states should be exactly the minimum maximal matchings of
-        # G
-        sampleset = dimod.ExactSolver().sample(bqm)
-
-        # we'd like to use sampleset.lowest() but it didn't exist in dimod
-        # 0.8.0
-        ground_energy = sampleset.first.energy
-        cardinalities = set()
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            if energy > ground_energy:
-                continue
-            edges = set(v for v, val in sample.items() if val > 0)
-            self.assertTrue(nx.is_maximal_matching(self.graph, edges))
-            cardinalities.add(len(edges))
-
-        # all ground have the same cardinality (or it's empty)
-        self.assertEqual(len(cardinalities), 1)
-        cardinality, = cardinalities
-
-        # everything that's not ground has a higher energy
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            edges = set(v for v, val in sample.items() if val > 0)
-            if energy != sampleset.first.energy:
-                if nx.is_maximal_matching(self.graph, edges):
-                    self.assertGreater(len(edges), cardinality)

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -28,36 +28,31 @@ class TestPartitioning(unittest.TestCase):
         self.assertTrue(node_partitions == {})
 
     def test_typical_cases(self):
-
         G = nx.complete_graph(8)
 
         node_partitions = dwave.graphs.partition(G, num_partitions=4, sampler=ExactCQMSolver())
         for i in range(4):
             self.assertTrue(sum(x == i for x in node_partitions.values()) == 2) # 4 equally sized subsets
 
-
         G = nx.complete_graph(10)
         node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) == 5)  # half of the nodes in subset '0'
-
 
         nx.set_edge_attributes(G, 1, 'weight')
         node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) == 5)  # half of the nodes in subset '0'
 
-
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (3, 4), (2, 4)])
         node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) in (2, 3)) # either 2 or 3 nodes in subset '0' (ditto '1')
-        
+
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3), (3, 4), (3, 5), (4, 5)])
         node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(node_partitions[0] == node_partitions[1] == node_partitions[2])
         self.assertTrue(node_partitions[3] == node_partitions[4] == node_partitions[5])
-        
-        
+
         nx.set_edge_attributes(G, values = 1, name = 'weight')
         nx.set_edge_attributes(G, values = {(2, 3): 100}, name='weight')
         node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -15,50 +15,50 @@
 import unittest
 
 import networkx as nx
-import dwave.graphs as dnx
 from dimod import ExactCQMSolver
+
+import dwave.graphs
 
 
 class TestPartitioning(unittest.TestCase):
     def test_edge_cases(self):
-        # get the empty graph
         G = nx.Graph()
 
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(node_partitions == {})
 
     def test_typical_cases(self):
 
         G = nx.complete_graph(8)
 
-        node_partitions = dnx.partition(G, num_partitions=4, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, num_partitions=4, sampler=ExactCQMSolver())
         for i in range(4):
             self.assertTrue(sum(x == i for x in node_partitions.values()) == 2) # 4 equally sized subsets
 
 
         G = nx.complete_graph(10)
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) == 5)  # half of the nodes in subset '0'
 
 
         nx.set_edge_attributes(G, 1, 'weight')
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) == 5)  # half of the nodes in subset '0'
 
 
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (3, 4), (2, 4)])
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(sum(x == 0 for x in node_partitions.values()) in (2, 3)) # either 2 or 3 nodes in subset '0' (ditto '1')
         
         G = nx.Graph()
         G.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3), (3, 4), (3, 5), (4, 5)])
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(node_partitions[0] == node_partitions[1] == node_partitions[2])
         self.assertTrue(node_partitions[3] == node_partitions[4] == node_partitions[5])
         
         
         nx.set_edge_attributes(G, values = 1, name = 'weight')
         nx.set_edge_attributes(G, values = {(2, 3): 100}, name='weight')
-        node_partitions = dnx.partition(G, sampler=ExactCQMSolver())
+        node_partitions = dwave.graphs.partition(G, sampler=ExactCQMSolver())
         self.assertTrue(node_partitions[2] == node_partitions[3]) # weight edges are respected

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -12,12 +12,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import unittest
 import itertools
+import unittest
 
 import networkx as nx
-import dwave.graphs as dnx
-from dimod import ExactSolver, SimulatedAnnealingSampler
+from dimod import ExactSolver
+
+import dwave.graphs
 
 
 class TestSocial(unittest.TestCase):
@@ -43,7 +44,7 @@ class TestSocial(unittest.TestCase):
             for p1 in redteam1:
                 S.add_edge(p0, p1, sign=-1)
 
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
         self.check_bicolor(colors)
 
         greenteam = ['Ted']
@@ -51,7 +52,7 @@ class TestSocial(unittest.TestCase):
             for p1 in greenteam:
                 S.add_edge(p0, p1, sign=1)
 
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
         self.check_bicolor(colors)
 
     def test_structural_imbalance_docstring_example(self):
@@ -61,13 +62,13 @@ class TestSocial(unittest.TestCase):
         S.add_edge('Alice', 'Bob', sign=1)  # Alice and Bob are friendly
         S.add_edge('Alice', 'Eve', sign=-1)  # Alice and Eve are hostile
         S.add_edge('Bob', 'Eve', sign=-1)  # Bob and Eve are hostile
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
         self.check_bicolor(colors)
         self.assertEqual(frustrated_edges, {})
         S.add_edge('Ted', 'Bob', sign=1)  # Ted is friendly with all
         S.add_edge('Ted', 'Alice', sign=1)
         S.add_edge('Ted', 'Eve', sign=1)
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
         self.check_bicolor(colors)
         self.assertTrue(frustrated_edges == {('Ted', 'Eve'): {'sign': 1}} or
                         frustrated_edges == {('Eve', 'Ted'): {'sign': 1}})
@@ -80,7 +81,7 @@ class TestSocial(unittest.TestCase):
         S.add_edge('Bob', 'Eve')  # invalid edge
 
         with self.assertRaises(ValueError):
-            frustrated_edges, colors = dnx.structural_imbalance(S, ExactSolver())
+            frustrated_edges, colors = dwave.graphs.structural_imbalance(S, ExactSolver())
 
     def test_sign_zero(self):
         """though not documentented, agents with no relation can have sign 0.
@@ -92,7 +93,7 @@ class TestSocial(unittest.TestCase):
         S.add_edge('Alice', 'Eve', sign=-1)  # Alice and Eve are hostile
         S.add_edge('Bob', 'Eve', sign=0)  # Bob and Eve have no relation
 
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
 
         self.assertEqual(frustrated_edges, {})  # should be no frustration
 
@@ -106,5 +107,5 @@ class TestSocial(unittest.TestCase):
         nx.set_edge_attributes(S, -1, 'sign')
 
         # smoke test
-        frustrated_edges, colors = dnx.structural_imbalance(S, sampler)
+        frustrated_edges, colors = dwave.graphs.structural_imbalance(S, sampler)
         self.check_bicolor(colors)

--- a/tests/test_tsp.py
+++ b/tests/test_tsp.py
@@ -15,11 +15,10 @@
 import itertools
 import unittest
 
+import dimod
 import networkx as nx
 
-import dimod
-
-import dwave.graphs as dnx
+from dwave.graphs import is_hamiltonian_path, traveling_salesperson
 
 
 # adapted from future networkx version (nx.path_weight(...))
@@ -37,36 +36,35 @@ class TestIsHamiltonCycle(unittest.TestCase):
     def test_empty(self):
         G = nx.Graph()
 
-        self.assertTrue(dnx.is_hamiltonian_path(G, []))
+        self.assertTrue(is_hamiltonian_path(G, []))
 
     def test_K1(self):
         G = nx.complete_graph(1)
 
-        self.assertTrue(dnx.is_hamiltonian_path(G, [0]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, []))
+        self.assertTrue(is_hamiltonian_path(G, [0]))
+        self.assertFalse(is_hamiltonian_path(G, []))
 
     def test_K2(self):
         G = nx.complete_graph(2)
 
-        self.assertTrue(dnx.is_hamiltonian_path(G, [0, 1]))
-        self.assertTrue(dnx.is_hamiltonian_path(G, [1, 0]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, [0]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, [1]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, []))
+        self.assertTrue(is_hamiltonian_path(G, [0, 1]))
+        self.assertTrue(is_hamiltonian_path(G, [1, 0]))
+        self.assertFalse(is_hamiltonian_path(G, [0]))
+        self.assertFalse(is_hamiltonian_path(G, [1]))
+        self.assertFalse(is_hamiltonian_path(G, []))
 
     def test_K3(self):
         G = nx.complete_graph(3)
 
-        self.assertTrue(dnx.is_hamiltonian_path(G, [0, 1, 2]))
-        self.assertTrue(dnx.is_hamiltonian_path(G, [1, 0, 2]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, [0, 1]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, [0]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, [1]))
-        self.assertFalse(dnx.is_hamiltonian_path(G, []))
+        self.assertTrue(is_hamiltonian_path(G, [0, 1, 2]))
+        self.assertTrue(is_hamiltonian_path(G, [1, 0, 2]))
+        self.assertFalse(is_hamiltonian_path(G, [0, 1]))
+        self.assertFalse(is_hamiltonian_path(G, [0]))
+        self.assertFalse(is_hamiltonian_path(G, [1]))
+        self.assertFalse(is_hamiltonian_path(G, []))
 
 
 class TestTSP(unittest.TestCase):
-
     def test_TSP_basic(self):
         """Runs the function on some small and simple graphs, just to make
         sure it works in basic functionality.
@@ -74,28 +72,28 @@ class TestTSP(unittest.TestCase):
         G = nx.complete_graph(4)
         for u, v in G.edges():
             G[u][v]['weight'] = 1
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver())
-        self.assertTrue(dnx.is_hamiltonian_path(G, route))
+        route = traveling_salesperson(G, dimod.ExactSolver())
+        self.assertTrue(is_hamiltonian_path(G, route))
 
         G = nx.complete_graph(4)
         for u, v in G.edges():
             G[u][v]['weight'] = u+v
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), lagrange=10.0)
-        self.assertTrue(dnx.is_hamiltonian_path(G, route))
+        route = traveling_salesperson(G, dimod.ExactSolver(), lagrange=10.0)
+        self.assertTrue(is_hamiltonian_path(G, route))
 
     def test_dimod_vs_list(self):
         G = nx.complete_graph(4)
         for u, v in G.edges():
             G[u][v]['weight'] = 1
 
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver())
-        route = dnx.traveling_salesperson(G, dimod.SimulatedAnnealingSampler())
+        route = traveling_salesperson(G, dimod.ExactSolver())
+        route = traveling_salesperson(G, dimod.SimulatedAnnealingSampler())
 
     def test_weighted_complete_graph(self):
         G = nx.Graph()
         G.add_weighted_edges_from({(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 2, 3),
                                    (1, 3, 4), (2, 3, 5)})
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), lagrange=10)
+        route = traveling_salesperson(G, dimod.ExactSolver(), lagrange=10)
 
         self.assertEqual(len(route), len(G))
 
@@ -104,7 +102,7 @@ class TestTSP(unittest.TestCase):
         G.add_weighted_edges_from((u, v, .5)
                                   for u, v in itertools.combinations(range(3), 2))
 
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), start=1)
+        route = traveling_salesperson(G, dimod.ExactSolver(), start=1)
 
         self.assertEqual(route[0], 1)
 
@@ -125,7 +123,7 @@ class TestTSP(unittest.TestCase):
             (3, 2, 1),
         ])
 
-        route = dnx.traveling_salesperson(G, dimod.ExactSolver(), start=1)
+        route = traveling_salesperson(G, dimod.ExactSolver(), start=1)
 
         self.assertEqual(len(route), len(G))
         self.assertListEqual(route, [1, 0, 3, 2])
@@ -133,233 +131,3 @@ class TestTSP(unittest.TestCase):
         cost = path_weight(G, route)
 
         self.assertEqual(cost, 4)
-
-
-class TestTSPQUBO(unittest.TestCase):
-    def test_empty(self):
-        Q = dnx.traveling_salesperson_qubo(nx.Graph())
-        self.assertEqual(Q, {})
-
-    def test_k3(self):
-        # 3cycle so all paths are equally good
-        G = nx.Graph()
-        G.add_weighted_edges_from([('a', 'b', 0.5),
-                                   ('b', 'c', 1.0),
-                                   ('a', 'c', 2.0)])
-
-        Q = dnx.traveling_salesperson_qubo(G, lagrange=10)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-        # all routes are min weight
-        min_routes = list(itertools.permutations(G.nodes))
-
-        # get the min energy of the qubo
-        sampleset = dimod.ExactSolver().sample(bqm)
-        ground_energy = sampleset.first.energy
-
-        # all possible routes are equally good
-        for route in min_routes:
-            sample = {v: 0 for v in bqm.variables}
-            for idx, city in enumerate(route):
-                sample[(city, idx)] = 1
-            self.assertAlmostEqual(bqm.energy(sample), ground_energy)
-
-        # all min-energy solutions are valid routes
-        ground_count = 0
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            if abs(energy - ground_energy) > .001:
-                break
-            ground_count += 1
-
-        self.assertEqual(ground_count, len(min_routes))
-
-    def test_k3_bidirectional(self):
-        G = nx.DiGraph()
-        G.add_weighted_edges_from([('a', 'b', 0.5),
-                                   ('b', 'a', 0.5),
-                                   ('b', 'c', 1.0),
-                                   ('c', 'b', 1.0),
-                                   ('a', 'c', 2.0),
-                                   ('c', 'a', 2.0)])
-
-        Q = dnx.traveling_salesperson_qubo(G, lagrange=10)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-        # all routes are min weight
-        min_routes = list(itertools.permutations(G.nodes))
-
-        # get the min energy of the qubo
-        sampleset = dimod.ExactSolver().sample(bqm)
-        ground_energy = sampleset.first.energy
-
-        # all possible routes are equally good
-        for route in min_routes:
-            sample = {v: 0 for v in bqm.variables}
-            for idx, city in enumerate(route):
-                sample[(city, idx)] = 1
-            self.assertAlmostEqual(bqm.energy(sample), ground_energy)
-
-        # all min-energy solutions are valid routes
-        ground_count = 0
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            if abs(energy - ground_energy) > .001:
-                break
-            ground_count += 1
-
-        self.assertEqual(ground_count, len(min_routes))
-
-    def test_graph_missing_edges(self):
-        G1 = nx.Graph()
-        G1.add_weighted_edges_from([
-            ('a', 'b', 0.5),
-            ('b', 'c', 1.0),
-            ('a', 'c', 2.0),
-        ])
-        Q1 = dnx.traveling_salesperson_qubo(G1, lagrange=10)
-
-        G2 = nx.Graph()
-        G2.add_weighted_edges_from([
-            ('a', 'b', 0.5),
-            ('a', 'c', 2.0),
-        ])
-        # make sure that missing_edge_weight gets applied correctly
-        Q2 = dnx.traveling_salesperson_qubo(G2, lagrange=10, missing_edge_weight=1.0)
-
-        self.assertDictEqual(Q1, Q2)
-
-    def test_digraph_missing_edges(self):
-        G1 = nx.DiGraph()
-        G1.add_weighted_edges_from([
-            ('a', 'b', 0.5),
-            ('b', 'a', 0.8),
-            ('b', 'c', 1.0),
-            ('c', 'b', 0.7),
-            ('a', 'c', 2.0),
-            ('c', 'a', 2.0),
-        ])
-        Q1 = dnx.traveling_salesperson_qubo(G1, lagrange=10)
-
-        G2 = nx.DiGraph()
-        G2.add_weighted_edges_from([
-            ('a', 'b', 0.5),
-            ('b', 'a', 0.8),
-            ('c', 'b', 0.7),
-            ('a', 'c', 2.0),
-            ('c', 'a', 2.0),
-        ])
-
-        # make sure that missing_edge_weight gets applied correctly
-        Q2 = dnx.traveling_salesperson_qubo(G2, lagrange=10, missing_edge_weight=1.0)
-
-        self.assertDictEqual(Q1, Q2)
-
-    def test_k4_equal_weights(self):
-        # k5 with all equal weights so all paths are equally good
-        G = nx.Graph()
-        G.add_weighted_edges_from((u, v, .5)
-                                  for u, v in itertools.combinations(range(4), 2))
-
-        Q = dnx.traveling_salesperson_qubo(G, lagrange=10)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-        # all routes are min weight
-        min_routes = list(itertools.permutations(G.nodes))
-
-        # get the min energy of the qubo
-        sampleset = dimod.ExactSolver().sample(bqm)
-        ground_energy = sampleset.first.energy
-
-        # all possible routes are equally good
-        for route in min_routes:
-            sample = {v: 0 for v in bqm.variables}
-            for idx, city in enumerate(route):
-                sample[(city, idx)] = 1
-            self.assertAlmostEqual(bqm.energy(sample), ground_energy)
-
-        # all min-energy solutions are valid routes
-        ground_count = 0
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            if abs(energy - ground_energy) > .001:
-                break
-            ground_count += 1
-
-        self.assertEqual(ground_count, len(min_routes))
-
-    def test_k4(self):
-        # good routes are 0,1,2,3 or 3,2,1,0 (and their rotations)
-        G = nx.Graph()
-        G.add_weighted_edges_from([(0, 1, 1),
-                                   (1, 2, 1),
-                                   (2, 3, 1),
-                                   (3, 0, 1),
-                                   (0, 2, 2),
-                                   (1, 3, 2)])
-
-        Q = dnx.traveling_salesperson_qubo(G, lagrange=10)
-        bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-        # good routes won't have 0<->2 or 1<->3
-        min_routes = [(0, 1, 2, 3),
-                      (1, 2, 3, 0),
-                      (2, 3, 0, 1),
-                      (1, 2, 3, 0),
-                      (3, 2, 1, 0),
-                      (2, 1, 0, 3),
-                      (1, 0, 3, 2),
-                      (0, 3, 2, 1)]
-
-        # get the min energy of the qubo
-        sampleset = dimod.ExactSolver().sample(bqm)
-        ground_energy = sampleset.first.energy
-
-        # all possible routes are equally good
-        for route in min_routes:
-            sample = {v: 0 for v in bqm.variables}
-            for idx, city in enumerate(route):
-                sample[(city, idx)] = 1
-            self.assertAlmostEqual(bqm.energy(sample), ground_energy)
-
-        # all min-energy solutions are valid routes
-        ground_count = 0
-        for sample, energy in sampleset.data(['sample', 'energy']):
-            if abs(energy - ground_energy) > .001:
-                break
-            ground_count += 1
-
-        self.assertEqual(ground_count, len(min_routes))
-
-    def test_weighted_complete_graph(self):
-        G = nx.Graph()
-        G.add_weighted_edges_from({(0, 1, 1), (0, 2, 100),
-                                   (0, 3, 1), (1, 2, 1),
-                                   (1, 3, 100), (2, 3, 1)})
-
-        lagrange = 5.0
-
-        Q = dnx.traveling_salesperson_qubo(G, lagrange, 'weight')
-
-        N = G.number_of_nodes()
-        correct_sum = G.size('weight')*2*N-2*N*N*lagrange+2*N*N*(N-1)*lagrange
-
-        actual_sum = sum(Q.values())
-
-        self.assertEqual(correct_sum, actual_sum)
-
-    def test_exceptions(self):
-        G = nx.Graph([(0, 1)])
-        with self.assertRaises(ValueError):
-            dnx.traveling_salesperson_qubo(G)
-
-    def test_docstring_size(self):
-        # in the docstring we state the size of the resulting BQM, this checks
-        # that
-        for n in range(3, 20):
-            G = nx.Graph()
-            G.add_weighted_edges_from((u, v, .5)
-                                      for u, v
-                                      in itertools.combinations(range(n), 2))
-            Q = dnx.traveling_salesperson_qubo(G)
-            bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
-
-            self.assertEqual(len(bqm), n**2)
-            self.assertEqual(len(bqm.quadratic), 2*n*n*(n - 1))


### PR DESCRIPTION
### Summary

- All BQM/Ising/QUBO generators from `dwave.graphs.algorithms` have been
  migrated to `dimod.generators` (released in `dimod==0.12.22`):
  - `min_vertex_color_qubo` and `vertex_color_qubo` removed from
    `dwave.graphs.algorithms.coloring` in favor of `min_vertex_coloring`
    and `vertex_coloring` from `dimod.generators.coloring`,
  - `dwave.graphs.algorithms.markov.markov_network_bqm` removed in favor
    of `dimod.generators.markov.markov_network`,
  - `matching_bqm`, `maximal_matching_bqm` and
    `min_maximal_matching_bqm` removed from
    `dwave.graphs.algorithms.matching` in favor of `maximal_matching`
    and `min_maximal_matching` from `dimod.generators.matching`,
  - `dwave.graphs.algorithms.partition.graph_partition_cqm` removed in
    favor of `dimod.generators.partition.graph_partition`,
  - `dwave.graphs.algorithms.social.structural_imbalance_ising` removed
    in favor of `dimod.generators.social.structural_imbalance` and
  - `dwave.graphs.algorithms.tsp.traveling_salesperson_qubo` removed in
    favor of `dimod.generators.tsp.traveling_salesperson`.


#### AI Generation Disclosure

No AI tools used.