### PR TITLE
Release 1.0.0

### DIFF
--- a/dwave/graphs/__init__.py
+++ b/dwave/graphs/__init__.py
@@ -23,4 +23,4 @@ from dwave.graphs.exceptions import *
 import dwave.graphs.drawing
 from dwave.graphs.drawing import *
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0"


### PR DESCRIPTION
### Prelude

Create `dwave-graphs` package based off `dwave-networkx`.
`dwave_networkx` namespace is renamed to `dwave.graphs`.

Binary quadratic model (i.e. Ising model and QUBO) generators have been
moved from `dwave.graphs.algorithms` to `dimod.generators`.

### New Features

- Add support for Python 3.14.

<!-- -->

- Modernize package config.

### Upgrade Notes

- Drop support for Python 3.9.

<!-- -->

- Drop support for `dimod<0.12`.

<!-- -->

- Remove deprecated Chimera and Pegasus coordinates transformation alias
  methods (`int`/`tuple`/etc in favor of explicit e.g.
  `chimera_to_linear`).

<!-- -->

- Remove deprecated `is_matching` and `is_maximal_matching` functions
  from `dwave.graphs.algorithms.matching`. Use the NetworkX
  implementations instead.

<!-- -->

- Drop the default sampler interface previously available in
  `dwave-networkx`. Some algorithms now explicitly require a sampler.

<!-- -->

- Drop `utils` and `utils.decorators` submodules, as well as the
  `@binary_quadratic_model_sampler` decorator.

<!-- -->

- All BQM/Ising/QUBO generators from `dwave.graphs.algorithms` have been
  migrated to `dimod.generators` (released in `dimod==0.12.22`):
  - `min_vertex_color_qubo` and `vertex_color_qubo` removed from
    `dwave.graphs.algorithms.coloring` in favor of `min_vertex_coloring`
    and `vertex_coloring` from `dimod.generators.coloring`,
  - `dwave.graphs.algorithms.markov.markov_network_bqm` removed in favor
    of `dimod.generators.markov.markov_network`,
  - `matching_bqm`, `maximal_matching_bqm` and
    `min_maximal_matching_bqm` removed from
    `dwave.graphs.algorithms.matching` in favor of `maximal_matching`
    and `min_maximal_matching` from `dimod.generators.matching`,
  - `dwave.graphs.algorithms.partition.graph_partition_cqm` removed in
    favor of `dimod.generators.partition.graph_partition`,
  - `dwave.graphs.algorithms.social.structural_imbalance_ising` removed
    in favor of `dimod.generators.social.structural_imbalance` and
  - `dwave.graphs.algorithms.tsp.traveling_salesperson_qubo` removed in
    favor of `dimod.generators.tsp.traveling_salesperson`.

<!-- -->

- Drop support for `dimod<0.12.22`.

<!-- -->

- Drop `vertex_color` and `min_vertex_color` aliases in favor of
  `vertex_coloring` and `min_vertex_coloring` for consistency.

<!-- -->

- Drop support for NumPy 1.x.

<!-- -->

- Replace dev/test/docs `requirements.txt` files with Dependency Groups
  (PEP-735).

<!-- -->

- `dwave.graphs.topologies` renamed to `dwave.graphs.topologies`.

<!-- -->

- Topology specific coloring functions, `zephyr_four_color()`,
  `pegasus_four_color()`, and `chimera_two_color()`, are moved from
  `dwave.graphs.topologies` to `dwave.graphs.algorithms.coloring`.
